### PR TITLE
added new config to prevent access to WEB-INF

### DIFF
--- a/share/src/main/resources/alfresco/share-config.xml
+++ b/share/src/main/resources/alfresco/share-config.xml
@@ -58,6 +58,7 @@
          <!-- Specify the list of path patterns to deny access for (via ResourceController). -->
          <deny-access-resource-paths>
             <resource-path-pattern>^/WEB-INF/.*</resource-path-pattern>
+            <resource-path-pattern>.*/WEB-INF/.*</resource-path-pattern>
             <resource-path-pattern>.*/\.\./WEB-INF/.*</resource-path-pattern>
             <resource-path-pattern>.*/classes/.*\.properties</resource-path-pattern>
          </deny-access-resource-paths>


### PR DESCRIPTION
I added new regular expression . It seems that this .*/\.\./WEB-INF/.* is not correctly evaluate. With the new one .*/WEB-INF/.* the WEB-INF folder is not anymore exposed.