### PR TITLE
Feature request: Extension point to enhancing share forms

### DIFF
--- a/web-framework-commons/src/main/java/org/alfresco/web/config/forms/FormConfigElement.java
+++ b/web-framework-commons/src/main/java/org/alfresco/web/config/forms/FormConfigElement.java
@@ -683,7 +683,7 @@ public class FormConfigElement extends ConfigElementAdapter
         return result;
     }
 
-    /* package */void setSubmissionURL(String newURL)
+    public void setSubmissionURL(String newURL)
     {
         this.submissionURL = newURL;
     }

--- a/web-framework-commons/src/main/java/org/alfresco/web/scripts/forms/FormUIGet.java
+++ b/web-framework-commons/src/main/java/org/alfresco/web/scripts/forms/FormUIGet.java
@@ -274,6 +274,14 @@ public class FormUIGet extends DeclarativeWebScript
         FormConfigElement formConfig = getFormConfig(itemId, formId);
         List<String> visibleFields = getVisibleFields(mode, formConfig);
         
+        // In order to pass submissionUrl formConfig cannot be null
+        if (formConfig == null)
+        {
+        	formConfig = new FormConfigElement();
+        }
+        String submissionUrl = getParameter(request, PARAM_SUBMISSION_URL);
+        formConfig.setSubmissionURL(submissionUrl);
+        
         // get the form definition from the form service
         Response formSvcResponse = retrieveFormDefinition(itemKind, itemId, visibleFields, formConfig);
         if (formSvcResponse.getStatus().getCode() == Status.STATUS_OK)
@@ -551,6 +559,21 @@ public class FormUIGet extends DeclarativeWebScript
         writer.writeValue(PARAM_ITEM_KIND, itemKind);
         writer.writeValue(PARAM_ITEM_ID, itemId.replace(":/", ""));
 
+        // pass the submissionUrl in the body
+        if (formConfig.getSubmissionURL() != null)
+	    {
+	    	writer.startValue(MODEL_SUBMISSION_URL);
+	    	writer.writeValue(formConfig.getSubmissionURL());
+	    	writer.endValue();
+	    }
+	    // pass the formId in the body
+	    if (formConfig.getId() != null)
+	    {
+	    	writer.startValue(PARAM_FORM_ID);
+	    	writer.writeValue(formConfig.getId());
+	    	writer.endValue();
+	    }
+        
         List<String> forcedFields = null;
         if (visibleFields != null && visibleFields.size() > 0)
         {


### PR DESCRIPTION
## I'm submitting a ...  
```
[ ] bug report => search github for a similar issue or PR before submitting
[x] feature request
```

## Current Behavior
When creating a form processing filter, like described in https://docs.alfresco.com/5.2/concepts/dev-extensions-share-form-filters.html, developers do not have access to which form they're processing (formId) or where it will be submitted (submissionUrl)

## Expected Behavior
Simple extensions in custom form processing filters should be possible, where you could pass a context nodeRef (like parentRef) in the submissionUrl, so you could use the nodeService to grab specific metadata from a parent (or other) nodeRef and **pre-fill** a form through the form processing filter.
Other distinctions, like the formId, would make it easy to distinguish, for example, create forms from search forms, so you could pre-fill values on a create form, and do something different with the search form.

These are just examples, the added value of passing formId and submissionUrl would allow developers to use form processing filters to far greater extend then is currently possible.

## Caveat
Backend the following also needs to be modified:
- formdefinition.post.json.js to pass the values to the ScriptFormService
- the org.alfresco.repo.forms.script.ScriptFormService, which needs to accept these as additional parameters, where they can be put in a _Map<String, Object> context_ to be passed to the org.alfresco.repo.forms.FormService method _getForm(Item item, List<String> fields, List<String> forcedFields, Map<String, Object> context)_ Currently the context object is not used, and always passed as null from the ScriptFormService.

I'll happily provide more specifics or code if requested.

## Business case

Pre-filling forms with metadata coming from an external source (parent folder, categorization, ...) is a requirement often asked. Different behaviour for different types of forms as well.

Currently it is only achievable with the forms processor filters by forcing these changes as extensions in a way which violate some best practices (like having to use java reflection to access a setter and the alfresco package name), and only if the developer knows how to do it.

By building this extension point into Share (and the Repo), all developers have the formId and submissionUrl at their fingertips in their own custom form processing filters, which allows them to do a wide range of extensions. (And make their customers happy)