### PR TITLE
GOOGLEDOCS-432 : Update GoogleDocs Share AMP version for Share 6.0 pa…

### DIFF
--- a/packaging/docker/pom.xml
+++ b/packaging/docker/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>
         <!-- Alfresco GoogleDocs integration version -->
-        <alfresco.googledocs.version>3.0.4.2</alfresco.googledocs.version>
+        <alfresco.googledocs.version>3.1.0-RC1</alfresco.googledocs.version>
     </properties>
 
     <dependencies>
@@ -32,6 +32,7 @@
             <groupId>org.alfresco.integrations</groupId>
             <artifactId>alfresco-googledocs-share</artifactId>
             <version>${alfresco.googledocs.version}</version>
+            <classifier>community</classifier>
             <type>amp</type>
         </dependency>
     </dependencies>
@@ -101,6 +102,7 @@
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-googledocs-share</artifactId>
                                     <version>${alfresco.googledocs.version}</version>
+                                    <classifier>community</classifier>
                                     <type>amp</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>


### PR DESCRIPTION
…ckaging (docker)

Updates the GoogleDocs AMPs to version 3.1.0.-RC1, which is compatible with ACS 6.* (updated dependencies, updated Spring configuration files).
The related changes have already been pushed on acs-packaging and acs-community-packaging.

JIRA issues:
- https://issues.alfresco.com/jira/browse/GOOGLEDOCS-432
- https://issues.alfresco.com/jira/browse/GOOGLEDOCS-418 (parent task)