### PR TITLE
Ace 5842 csrf filter in docker

### DIFF
--- a/packaging/docker/docker-compose/docker-compose.yml
+++ b/packaging/docker/docker-compose/docker-compose.yml
@@ -4,11 +4,6 @@ services:
     alfresco:
         image: ${REPOSITORY_IMAGE}:${REPOSITORY_TAG}
         environment:
-            CATALINA_OPTS : "
-                  -agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n
-                        "
-            ports:
-                  -8000:8000
             JAVA_OPTS : "
                 -Ddb.driver=org.postgresql.Driver
                 -Ddb.username=alfresco

--- a/packaging/docker/docker-compose/docker-compose.yml
+++ b/packaging/docker/docker-compose/docker-compose.yml
@@ -4,6 +4,11 @@ services:
     alfresco:
         image: ${REPOSITORY_IMAGE}:${REPOSITORY_TAG}
         environment:
+            CATALINA_OPTS : "
+                  -agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n
+                        "
+            ports:
+                  -8000:8000
             JAVA_OPTS : "
                 -Ddb.driver=org.postgresql.Driver
                 -Ddb.username=alfresco
@@ -14,6 +19,7 @@ services:
                 -Dsolr.secureComms=none
                 -Dsolr.base.url=/solr
                 -Dindex.subsystem.name=solr6
+                -Dalfresco-pdf-renderer.url=http://alfresco-pdf-renderer:8090/
                 "
         ports:
             - ${REPOSITORY_PORT}:8080 #Browser port
@@ -21,8 +27,14 @@ services:
     share:
         image: ${SHARE_IMAGE}:${SHARE_TAG}
         environment:
-            - REPO_HOST=alfresco
-            - REPO_PORT=8080
+            REPO_HOST: alfresco
+            REPO_PORT: 8080
+            # CSRF setup
+            # if both csrf referer and csrf origin are set CSRFPolicy is set to true in share-config-custom.xml and overrides both properties
+            # if not CSRFPolicy is false
+            CSRF_FILTER_REFERER:
+            CSRF_FILTER_ORIGIN:
+            
         ports:
             - ${SHARE_PORT}:8080
 
@@ -48,3 +60,8 @@ services:
             - SOLR_CREATE_ALFRESCO_DEFAULTS=alfresco,archive
         ports:
             - ${SOLR_PORT}:8983 #Browser port
+            
+    alfresco-pdf-renderer:
+            image: alfresco/alfresco-pdf-renderer:0.10
+            ports:
+                - 8090:8090

--- a/packaging/docker/src/main/resources/web-extension-samples/share-config-custom.xml
+++ b/packaging/docker/src/main/resources/web-extension-samples/share-config-custom.xml
@@ -36,24 +36,238 @@
       </web-framework>
    </config>
 
-   <!-- Disable the CSRF Token Filter -->
+   
    <!--
-   <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
-      <filter/>
+      CSRF filter config to mitigate CSRF/Seasurfing/XSRF attacks
+
+      To disable the CSRF filter override the <filter> to not contain any values, see share-config-custom.xml for
+      an example.
+
+      If you have a custom resource(s) that a client POST to that can't accept a token, for whatever reason, then make
+      sure to copy the entire CSRFPolicy config and place it in your share-config-custom.xml file
+      with the replace="true" attribute and make sure to add a new <rule> in the top of the <filter> element,
+      which has a <request> element matching your requests, and uses only the "assertReferer" & "assertOrigin" actions.
+
+      I.e.
+      <rule>
+         <request>
+            <method>POST</method>
+            <path>/proxy/alfresco/custom/repoWebscript/withoutParams|/service/custom/shareResource/thatMayHaveParams(\?.+)?</path>
+         </request>
+         <action name="assertReferer">
+            <param name="referer">{referer}</param>
+         </action>
+         <action name="assertOrigin">
+            <param name="origin">{origin}</param>
+         </action>
+      </rule>
+   -->
+   <config evaluator="string-compare" condition="CSRFPolicy" replace="false">
+
+      <!--
+         Properties that may be used inside the rest of the CSRFPolicy config to avoid repetition but
+         also making it possible to provide different values in different environments.
+         I.e. Different "Referer" & "Origin" properties for test & production etc.
+         Reference a property using "{propertyName}".
+      -->
+      <properties>
+
+         <!-- There is normally no need to override this property -->
+         <token>Alfresco-CSRFToken</token>
+
+         <!--
+            Override and set this property with a regexp that if you have placed Share behind a proxy that
+            does not rewrite the Referer header.
+         -->
+         <referer></referer>
+
+         <!--
+            Override and set this property with a regexp that if you have placed Share behind a proxy that
+            does not rewrite the Origin header.
+         -->
+         <origin></origin>
+      </properties>
+
+      <!--
+        Will be used and exposed to the client side code in Alfresco.contants.CSRF_POLICY.
+        Use the Alfresco.util.CSRFPolicy.getHeader() or Alfresco.util.CSRFPolicy.getParameter() with Alfresco.util.CSRFPolicy.getToken()
+        to set the token in custom 3rd party code.
+      -->
+      <client>
+         <cookie>{token}</cookie>
+         <header>{token}</header>
+         <parameter>{token}</parameter>
+      </client>
+
+      <!-- The first rule with a matching request will get its action invoked, the remaining rules will be ignored. -->
+      <filter>
+
+         <!--
+            Certain webscripts shall not be allowed to be accessed directly form the browser.
+            Make sure to throw an error if they are used.
+         -->
+         <rule>
+            <request>
+               <path>/proxy/alfresco/remoteadm/.*</path>
+            </request>
+            <action name="throwError">
+               <param name="message">It is not allowed to access this url from your browser</param>
+            </action>
+         </rule>
+
+         <!--
+            Certain Repo webscripts should be allowed to pass without a token since they have no Share knowledge.
+            TODO: Refactor the publishing code so that form that is posted to this URL is a Share webscript with the right tokens.
+         -->
+         <rule>
+            <request>
+               <method>POST</method>
+               <path>/proxy/alfresco/api/publishing/channels/.+</path>
+            </request>
+            <action name="assertReferer">
+               <param name="referer">{referer}</param>
+            </action>
+            <action name="assertOrigin">
+               <param name="origin">{origin}</param>
+            </action>
+         </rule>
+
+         <!--
+            Certain Surf POST requests from the WebScript console must be allowed to pass without a token since
+            the Surf WebScript console code can't be dependent on a Share specific filter.
+         -->
+         <rule>
+            <request>
+               <method>POST</method>
+               <path>
+                  /page/caches/dependency/clear|/page/index|/page/surfBugStatus|/page/modules/deploy|/page/modules/module|/page/api/javascript/debugger|/page/console
+               </path>
+            </request>
+            <action name="assertReferer">
+               <param name="referer">{referer}</param>
+            </action>
+            <action name="assertOrigin">
+               <param name="origin">{origin}</param>
+            </action>
+         </rule>
+
+         <!-- Certain Share POST requests does NOT require a token -->
+         <rule>
+            <request>
+               <method>POST</method>
+               <path>
+                  /page/dologin(\?.+)?|/page/site/[^/]+/start-workflow|/page/start-workflow|/page/context/[^/]+/start-workflow
+               </path>
+            </request>
+            <action name="assertReferer">
+               <param name="referer">{referer}</param>
+            </action>
+            <action name="assertOrigin">
+               <param name="origin">{origin}</param>
+            </action>
+         </rule>
+
+         <!-- Assert logout is done from a valid domain, if so clear the token when logging out -->
+         <rule>
+            <request>
+               <method>POST</method>
+               <path>/page/dologout(\?.+)?</path>
+            </request>
+            <action name="assertReferer">
+               <param name="referer">{referer}</param>
+            </action>
+            <action name="assertOrigin">
+               <param name="origin">{origin}</param>
+            </action>
+            <action name="clearToken">
+               <param name="session">{token}</param>
+               <param name="cookie">{token}</param>
+            </action>
+         </rule>
+
+         <!-- Make sure the first token is generated -->
+         <rule>
+            <request>
+               <session>
+                  <attribute name="_alf_USER_ID">.+</attribute>
+                  <attribute name="{token}" />
+                  <!-- empty attribute element indicates null, meaning the token has not yet been set -->
+               </session>
+            </request>
+            <action name="generateToken">
+               <param name="session">{token}</param>
+               <param name="cookie">{token}</param>
+            </action>
+         </rule>
+
+         <!-- Refresh token on new "page" visit when a user is logged in -->
+         <rule>
+            <request>
+               <method>GET</method>
+               <path>/page/.*</path>
+               <session>
+                  <attribute name="_alf_USER_ID">.+</attribute>
+                  <attribute name="{token}">.+</attribute>
+               </session>
+            </request>
+            <action name="generateToken">
+               <param name="session">{token}</param>
+               <param name="cookie">{token}</param>
+            </action>
+         </rule>
+
+         <!--
+            Verify multipart requests from logged in users contain the token as a parameter
+            and also correct referer & origin header if available
+         -->
+         <rule>
+            <request>
+               <method>POST</method>
+               <header name="Content-Type">multipart/.+</header>
+               <session>
+                  <attribute name="_alf_USER_ID">.+</attribute>
+               </session>
+            </request>
+            <action name="assertToken">
+               <param name="session">{token}</param>
+               <param name="parameter">{token}</param>
+            </action>
+            <action name="assertReferer">
+               <param name="referer">{referer}</param>
+            </action>
+            <action name="assertOrigin">
+               <param name="origin">{origin}</param>
+            </action>
+         </rule>
+
+         <!--
+            Verify that all remaining state changing requests from logged in users' requests contains a token in the
+            header and correct referer & origin headers if available. We "catch" all content types since just setting it to
+            "application/json.*" since a webscript that doesn't require a json request body otherwise would be
+            successfully executed using i.e."text/plain".
+         -->
+         <rule>
+            <request>
+               <method>POST|PUT|DELETE</method>
+               <session>
+                  <attribute name="_alf_USER_ID">.+</attribute>
+               </session>
+            </request>
+            <action name="assertToken">
+               <param name="session">{token}</param>
+               <param name="header">{token}</param>
+            </action>
+            <action name="assertReferer">
+               <param name="referer">{referer}</param>
+            </action>
+            <action name="assertOrigin">
+               <param name="origin">{origin}</param>
+            </action>
+         </rule>
+      </filter>
+
    </config>
-   -->
 
-   <!--
-      To run the CSRF Token Filter behind 1 or more proxies that do not rewrite the Origin or Referere headers:
-
-      1. Copy the "CSRFPolicy" default config in share-security-config.xml and paste it into this file.
-      2. Replace the old config by setting the <config> element's "replace" attribute to "true" like below:
-         <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
-      3. To every <action name="assertReferer"> element add the following child element
-         <param name="referer">http://www.proxy1.com/.*|http://www.proxy2.com/.*</param>
-      4. To every <action name="assertOrigin"> element add the following child element
-         <param name="origin">http://www.proxy1.com|http://www.proxy2.com</param>
-   -->
 
    <!--
       Remove the default wildcard setting and use instead a strict whitelist of the only domains that shall be allowed

--- a/packaging/docker/substituter.sh
+++ b/packaging/docker/substituter.sh
@@ -13,4 +13,21 @@ echo "Replace 'REPO_HOST' with '$REPO_HOST' and 'REPO_PORT' with '$REPO_PORT'"
 
 sed -i -e 's/REPO_HOST:REPO_PORT/'"$REPO_HOST:$REPO_PORT"'/g' /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml
 
+echo "NEW -csrf.filter.referer is '$CSRF_FILTER_REFERER'"
+echo "NEW -csrf.filter.origin is '$CSRF_FILTER_ORIGIN'"
+
+if [ $CSRF_FILTER_REFERER != "" ] && [   $CSRF_FILTER_ORIGIN != "" ]; then
+# set CSRFPolicy to true and set both properties referer and origin
+   sed -i -e "s/<config evaluator=\"string-compare\" condition=\"CSRFPolicy\" replace=\"false\">/<config evaluator=\"string-compare\" condition=\"CSRFPolicy\" replace=\"true\">/" /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml
+   sed -i -e "s/<referer><\/referer>/<referer>$CSRF_FILTER_REFERER<\/referer>/" /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml
+   sed -i -e "s/<origin><\/origin>/<origin>$CSRF_FILTER_ORIGIN<\/origin>/" /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml
+   
+else
+# set CSRFPolicy to false and leave empty the properties referer and origin
+   sed -i -e "s/<config evaluator=\"string-compare\" condition=\"CSRFPolicy\" replace=\"false\">/<config evaluator=\"string-compare\" condition=\"CSRFPolicy\" replace=\"false\">/" /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml
+   sed -i -e "s/<referer><\/referer>/<referer><\/referer>/" /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml
+   sed -i -e "s/<origin><\/origin>/<origin><\/origin>/" /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml
+fi
+
+
 bash -c "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency.httpcomponents.version>4.5.1</dependency.httpcomponents.version>
         <dependency.alfresco-jlan.version>6.2</dependency.alfresco-jlan.version>                
         <dependency.alfresco-core.version>6.15</dependency.alfresco-core.version>
-        <dependency.webscripts.version>6.18-SNAPSHOT</dependency.webscripts.version>
+        <dependency.webscripts.version>6.18</dependency.webscripts.version>
         <dependency.surf.version>6.11</dependency.surf.version>
         <dependency.alfresco-sdk.version>2.0.0</dependency.alfresco-sdk.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency.httpcomponents.version>4.5.1</dependency.httpcomponents.version>
         <dependency.alfresco-jlan.version>6.2</dependency.alfresco-jlan.version>                
         <dependency.alfresco-core.version>6.15</dependency.alfresco-core.version>
-        <dependency.webscripts.version>6.15</dependency.webscripts.version>
+        <dependency.webscripts.version>6.18-SNAPSHOT</dependency.webscripts.version>
         <dependency.surf.version>6.11</dependency.surf.version>
         <dependency.alfresco-sdk.version>2.0.0</dependency.alfresco-sdk.version>
 


### PR DESCRIPTION
in docker-compose can be set CSRF_FILTER_REFERER and CSRF_FILTER_ORIGIN
substituter.sh makes overrides with those filters if are both set and set CSRFPolicy true otherwise
CSRFPolicy is false and <referer></referer> and <origin></origin> are empty