### PR TITLE
GOOGLEDOCS-437 : Generate Final Build for GoogleDocs 3.1.0 compatible with ACS Ent 6.0

### DIFF
--- a/packaging/docker/pom.xml
+++ b/packaging/docker/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>
         <!-- Alfresco GoogleDocs integration version -->
-        <alfresco.googledocs.version>3.1.0-RC2</alfresco.googledocs.version>
+        <alfresco.googledocs.version>3.1.0</alfresco.googledocs.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
   - updated googledocs dependency