### PR TITLE
Aikau version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <dependency.spring.version>3.2.14.RELEASE</dependency.spring.version>
         <dependency.yui.version>2.9.0-alfresco-20141223</dependency.yui.version>
-        <dependency.aikau.version>1.0.101.10</dependency.aikau.version>
+        <dependency.aikau.version>1.0.101.13</dependency.aikau.version>
         <dependency.freemarker.version>2.3.20-alfresco-patched</dependency.freemarker.version>
         <dependency.rhino.version>1.7R4-alfresco-patched</dependency.rhino.version>
         <dependency.httpcomponents.version>4.5.1</dependency.httpcomponents.version>


### PR DESCRIPTION
Updated aikau version with the new released one 1.101.13.
Sequences like %00 are not present in URLs after the update.