### PR TITLE
SHA-2199_incorrect_label

### DIFF
--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/dashlets/colleagues.get.properties
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/dashlets/colleagues.get.properties
@@ -6,7 +6,7 @@ link.all-members=All Members
 #{startRecord} - {endRecord} of {totalRecords}
 pagination.template={0} - {1} of {2}
 
-pagination.template2=Shown the first {0} members
+pagination.template2=Showing the first {0} members
 
 empty.title=You are the only site member.
 empty.description=


### PR DESCRIPTION
Fixed incorrect label from "Shown the first **n** members" to "Showing the first **n** members" 