### PR TITLE
REPO-3721 : Admin Console Link Invalid

### DIFF
--- a/share/src/main/java/org/alfresco/web/site/EditionInterceptor.java
+++ b/share/src/main/java/org/alfresco/web/site/EditionInterceptor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Share WAR
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2018 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/share/src/main/java/org/alfresco/web/site/EditionInterceptor.java
+++ b/share/src/main/java/org/alfresco/web/site/EditionInterceptor.java
@@ -62,6 +62,7 @@ public class EditionInterceptor extends AbstractWebFrameworkInterceptor
     /** public name of the value in the RequestContext */
     public static final String EDITION_INFO = "editionInfo";
     public static final String KEY_DOCS_EDITION = "docsEdition";
+    public static final String URL_UTIL = "urlUtil";
     
     public static final String ENTERPRISE_EDITION = EditionInfo.ENTERPRISE_EDITION;
     public static final String TEAM_EDITION = EditionInfo.TEAM_EDITION;
@@ -76,6 +77,7 @@ public class EditionInterceptor extends AbstractWebFrameworkInterceptor
      */
     private static EditionInfo EDITIONINFO = null;
     private static DocsEdition docsEdition = null;
+    private static UrlUtil urlUtil = new UrlUtil();
     
     private static volatile boolean outputInfo = false;
     private static volatile boolean outputEditionInfo = false;
@@ -155,6 +157,7 @@ public class EditionInterceptor extends AbstractWebFrameworkInterceptor
                                 // set edition info for current thread
                                 ThreadLocalRequestContext.getRequestContext().setValue(EDITION_INFO, editionInfo);
                                 ThreadLocalRequestContext.getRequestContext().setValue(KEY_DOCS_EDITION, docsEdition);
+                                ThreadLocalRequestContext.getRequestContext().setValue(URL_UTIL, urlUtil);
                                 
                                 // NOTE: We do NOT assign to the EDITIONINFO so that we re-evaluate next time.
                             }
@@ -219,6 +222,7 @@ public class EditionInterceptor extends AbstractWebFrameworkInterceptor
             {
                 ThreadLocalRequestContext.getRequestContext().setValue(EDITION_INFO, EDITIONINFO);
                 ThreadLocalRequestContext.getRequestContext().setValue(KEY_DOCS_EDITION, docsEdition);
+                ThreadLocalRequestContext.getRequestContext().setValue(URL_UTIL, urlUtil);
             }
         }
         finally

--- a/share/src/main/java/org/alfresco/web/site/UrlUtil.java
+++ b/share/src/main/java/org/alfresco/web/site/UrlUtil.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * Alfresco Share WAR
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.web.site;
+
+import com.google.common.base.Strings;
+
+import java.io.Serializable;
+
+/**
+ * A simple structure that reads the path to Alfresco Share and Alfresco Repository from JVM system properties.
+ *
+ * @author Alexandru Epure
+ */
+public class UrlUtil implements Serializable
+{
+    public static String alfrescoContext;
+    public static String alfrescoPort;
+    public static String alfrescoProtocol;
+    public static String alfrescoHost;
+    public static String alfrescoProxy;
+    public static String shareContext;
+    public static String sharePort;
+    public static String shareProtocol;
+    public static String shareHost;
+    public static String shareProxy;
+
+    private final String repoURL;
+    private final String shareURL;
+
+    public UrlUtil()
+    {
+        alfrescoContext = System.getProperty("alfresco.context");
+        alfrescoPort = System.getProperty("alfresco.port");
+        alfrescoProtocol = System.getProperty("alfresco.protocol");
+        alfrescoHost = System.getProperty("alfresco.host");
+        alfrescoProxy = System.getProperty("alfresco.proxy");
+        shareContext = System.getProperty("share.context");
+        sharePort = System.getProperty("share.port");
+        shareProtocol = System.getProperty("share.protocol");
+        shareHost = System.getProperty("share.host");
+        shareProxy = System.getProperty("share.proxy");
+        this.repoURL = getRepoURL();
+        this.shareURL = getShareURL();
+    }
+
+    public String getRepoURL()
+    {
+        if (!Strings.isNullOrEmpty(alfrescoProxy))
+        {
+            return alfrescoProxy;
+        }
+        if (!Strings.isNullOrEmpty(alfrescoProtocol) && !Strings.isNullOrEmpty(alfrescoHost) && !Strings.isNullOrEmpty(alfrescoPort))
+        {
+            return alfrescoProtocol + "://" + alfrescoHost + ":" + alfrescoPort;
+        }
+        return "";
+    }
+
+    public String getShareURL()
+    {
+        if (!Strings.isNullOrEmpty(shareProxy))
+        {
+            return shareProxy;
+        }
+        if (!Strings.isNullOrEmpty(shareProtocol) && !Strings.isNullOrEmpty(shareHost) && !Strings.isNullOrEmpty(sharePort))
+        {
+            return shareProtocol + "://" + shareHost + ":" + sharePort;
+        }
+        return "";
+    }
+}

--- a/share/src/main/java/org/alfresco/web/site/UrlUtil.java
+++ b/share/src/main/java/org/alfresco/web/site/UrlUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Share WAR
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2018 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -30,7 +30,7 @@ import com.google.common.base.Strings;
 import java.io.Serializable;
 
 /**
- * A simple structure that reads the path to Alfresco Share and Alfresco Repository from JVM system properties.
+ * A simple structure that supplies the path to Alfresco Share and Alfresco Repository from JVM system properties.
  *
  * @author Alexandru Epure
  */

--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/console/application.get.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/console/application.get.js
@@ -51,7 +51,6 @@ function main()
        var alfEndpointUrl = remote.getEndpointURL("alfresco");
        model.platUrl = alfEndpointUrl.substr(0, alfEndpointUrl.lastIndexOf("/"));
    }
-
 }
 
 main();

--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/console/application.get.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/console/application.get.js
@@ -41,8 +41,17 @@ function main()
    var editionInfo = context.properties["editionInfo"].edition;
    model.isEnterprise = "ENTERPRISE" == editionInfo;
 
-   var alfEndpointUrl = remote.getEndpointURL("alfresco");
-   model.platUrl = alfEndpointUrl.substr(0, alfEndpointUrl.lastIndexOf("/"));
+   var alfrescoPath = context.properties["urlUtil"].repoURL;
+   if (alfrescoPath != "")
+   {
+       model.platUrl = alfrescoPath + "/alfresco"
+   }
+   else
+   {
+       var alfEndpointUrl = remote.getEndpointURL("alfresco");
+       model.platUrl = alfEndpointUrl.substr(0, alfEndpointUrl.lastIndexOf("/"));
+   }
+
 }
 
 main();


### PR DESCRIPTION
   Create UrlUtil class which reads the path to Alfresco Share and Alfresco Repository from JVM system properties.
   Add UrlUtil object to EditionInterceptor as this "webscript context property" instead of creating a new Interceptor.
   Read "repoURL" from context and build the link to admin console (if repoURL != "") else use the old mechanism.