### PR TITLE
MNT-19374 addresses the reported issue as well as general consistency…

### DIFF
--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/document-details/document-versions.get.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/document-details/document-versions.get.js
@@ -15,6 +15,7 @@ function main()
       model.allowNewVersionUpload = (!documentDetails.item.node.isLocked && documentDetails.item.node.permissions.user["Write"]) || false;
       model.isWorkingCopy = (documentDetails.item && documentDetails.item.workingCopy && documentDetails.item.workingCopy.isWorkingCopy) ? true : false;
       model.exist = true;
+      model.documentDetails = true;
    }
    
    // Widget instantiation metadata...
@@ -25,6 +26,7 @@ function main()
          nodeRef : model.nodeRef,
          siteId : model.site,
          containerId : model.container,
+          documentDetails : documentDetails,
          workingCopyVersion : model.workingCopyVersion,
          allowNewVersionUpload : model.allowNewVersionUpload
       }


### PR DESCRIPTION
MNT-19374 - 'Upload New Version' UI consistency

This PR addresses the following:
1. the original issue decribed in MNT-19374 where the document versions were not updating properly (when using upload new version from document versions)
2. 'communications failure' message appearing briefly when a new version is uploaded through this mechanism
3. the change implemented in MNT-14924 was not replicated for this mechanism of upload new version