### PR TITLE
MNT-15977 - made create documents by node or folder templates submenu scrollable

### DIFF
--- a/share/src/main/webapp/components/documentlibrary/toolbar.css
+++ b/share/src/main/webapp/components/documentlibrary/toolbar.css
@@ -66,6 +66,12 @@
    padding: 2px 0px 1px 24px;
 }
 
+.toolbar-template-list
+{
+   max-height: 30em;
+   overflow-y: auto;
+}
+
 .toolbar .create-content ul div .yuimenuitemlabel span
 {
    padding: 2px 0px 1px 2px;

--- a/share/src/main/webapp/components/documentlibrary/toolbar.js
+++ b/share/src/main/webapp/components/documentlibrary/toolbar.js
@@ -328,7 +328,7 @@
 
                   // Create placeholder menu
                   var div = document.createElement("div");
-                  div.innerHTML = '<div class="bd"><ul></ul></div>';
+                  div.innerHTML = '<div class="bd toolbar-template-list"><ul></ul></div>';
 
                   // 
                   var li2 = document.createElement("li");
@@ -343,7 +343,7 @@
 
                   // Create placeholder menu
                   var div2 = document.createElement("div");
-                  div2.innerHTML = '<div class="bd"><ul></ul></div>';
+                  div2.innerHTML = '<div class="bd toolbar-template-list"><ul></ul></div>';
                   
                   // Add menu item
                   var createContentByTemplate = new YAHOO.widget.MenuItem(li, {


### PR DESCRIPTION
If there are lots of either template nodes or folders, when a user tries to create content/folder by these templates, the rendered menus are not scrollable making it difficult to get to a specific item out of the range of the list.