### PR TITLE
MNT-14338 - using more generic error response to the user when saving metadata

### DIFF
--- a/web-framework-commons/src/main/webapp/js/alfresco.js
+++ b/web-framework-commons/src/main/webapp/js/alfresco.js
@@ -11201,7 +11201,7 @@ Alfresco.util.RENDERLOOPSIZE = 25;
                Alfresco.util.PopupManager.displayPrompt(
                {
                   title: this.msg(this.options.failureMessageKey),
-                  text: failureMsg ? failureMsg : (response.json && response.json.message ? response.json.message : this.msg("message.details.failure"))
+                  text: failureMsg ? failureMsg : this.msg("message.unknown-error")
                });
             },
 


### PR DESCRIPTION
Using more generic error response to the user in the event of un-handled error saving metadata