### PR TITLE
MNT-20234 - (re) patched lesscss-engine and pulling in new dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,13 @@
                <groupId>org.alfresco.surf</groupId>
                <artifactId>spring-surf</artifactId>
                <version>${dependency.surf.version}</version>
+               <exclusions>
+               <!-- surf pulls in a an un-patched version, MNT-20234 -->
+                    <exclusion>
+                        <groupId>com.asual.lesscss</groupId>
+                        <artifactId>lesscss-engine</artifactId>
+                    </exclusion>
+               </exclusions>
             </dependency>
             <dependency>
                <groupId>org.alfresco.surf</groupId>

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -269,11 +269,12 @@
 
         <!-- This is used for the LESS CSS processing. It allows us to include LESS code in both
              the Theme XML files and in widget CSS files. We deliberately exclude it's preferred
-             Rhino version so as to avoid conflicts with our own dependencies. -->
+             Rhino version so as to avoid conflicts with our own dependencies. 
+             Using pateched version, MNT-20234 -->
         <dependency>
-            <groupId>com.asual.lesscss</groupId>
-            <artifactId>lesscss-engine</artifactId>
-            <version>1.5.1</version>
+          <groupId>org.alfresco.3rdparty.com.asual.lesscss</groupId>
+          <artifactId>lesscss-engine</artifactId>
+          <version>1.5.1-patched</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.mozilla</groupId>


### PR DESCRIPTION
Please see this comment for investigation and the reason for these changes:
https://issues.alfresco.com/jira/browse/MNT-20234?focusedCommentId=599321&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-599321

Basically created a new patched 'lesscss-engine' and pulling that in, also removing the possibility of pulling in duplicate library via spring-surf