### PR TITLE
MNT-16673 - removed overriding Users configuration from enterprise-config.xml

### DIFF
--- a/share/src/main/resources/alfresco/enterprise-config.xml
+++ b/share/src/main/resources/alfresco/enterprise-config.xml
@@ -15,15 +15,6 @@
       </login>
    </config>
 
-   <config evaluator="string-compare" condition="Users" replace="true">
-      <users>
-         <!-- minimum length for username and password -->
-         <username-min-length>2</username-min-length>
-         <password-min-length>3</password-min-length>
-         <show-authorization-status>true</show-authorization-status>
-      </users>
-   </config>
-
    <!-- ************************************** -->
    <!-- Hybrid Workflow Definition Form Configuration -->
    <!-- ************************************** -->


### PR DESCRIPTION
Pls see investigation https://issues.alfresco.com/jira/browse/MNT-16673?focusedCommentId=599641&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-599641

basically the configuration held in enterprise-config.xml negates any overriding configuration in share-config-custom.xml