### PR TITLE
MNT-16673 - removed overriding Users field length configuration from enterprise-config.xml

### DIFF
--- a/share/src/main/resources/alfresco/enterprise-config.xml
+++ b/share/src/main/resources/alfresco/enterprise-config.xml
@@ -15,11 +15,8 @@
       </login>
    </config>
 
-   <config evaluator="string-compare" condition="Users" replace="true">
+   <config evaluator="string-compare" condition="Users">
       <users>
-         <!-- minimum length for username and password -->
-         <username-min-length>2</username-min-length>
-         <password-min-length>3</password-min-length>
          <show-authorization-status>true</show-authorization-status>
       </users>
    </config>


### PR DESCRIPTION
Pls see investigation https://issues.alfresco.com/jira/browse/MNT-16673?focusedCommentId=599641&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-599641

Basically the configuration held in enterprise-config.xml negates any overriding configuration in share-config-custom.xml, this change specifically removes the field length configuration allowing for it to be overridden by the share-config-custom.xml (keeping the auth status display configuration).