### PR TITLE
MNT-20208 Sensitive Cookie in HTTPS Session Without 'Secure' Attribute CWE ID 614

### DIFF
--- a/share/src/main/webapp/WEB-INF/web.xml
+++ b/share/src/main/webapp/WEB-INF/web.xml
@@ -199,6 +199,10 @@
    
    <session-config>
       <session-timeout>60</session-timeout>
+      <!-- MNT-20208: secure the session (LM-190130) -->
+      <cookie-config>
+         <secure>true</secure>
+      </cookie-config>
    </session-config>
 
    <!-- welcome file list precedence order is index.jsp -->


### PR DESCRIPTION
Sensitive cookies without secure and httpOnly attributes are susceptible to eavesdropping when transmitted over unencrypted connections. Setting the Secure attribute on an HTTP cookie instructs the web browser to send it only over a secure channel, such as a TLS connection, while adding httpOnly attribute restrict all access via JavaScript in browsers.

Add configuration to control JSESSION secure attribute.