### PR TITLE
MNT-20195 Share - Information Exposure through verbose error messages

### DIFF
--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/html.status.ftl
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/html.status.ftl
@@ -1,6 +1,9 @@
 "'></a></script>
 <!-- above dodgy HTML is required to end any open tags, script etc. before further script injection -->
 
+<#-- MNT-20195 (LM-190214): import errorcode lib -->
+<#import "../errorcode.lib.ftl" as codeLib />
+
 <div class="theme-color-2" style="padding: 8px; margin: 8px; border: 1px dashed #D7D7D7;">
    <div style="font-weight: bold; font-size: 116%">
       <div style="padding: 2px">An error has occured in the Share component: ${url.service?html}.</div>
@@ -8,9 +11,13 @@
    </div>
    <div class="theme-color-4" style="padding-top:8px;">
       <div style="padding: 2px"><b>Error Code Information:</b> ${status.code} - ${status.codeDescription}</div>
+      <#-- MNT-20195 (LM-190214): hide server and time info, and display error log number/error message. -->
+      <#assign errorCode = codeLib.getErrorCode(status.message)>
+      <#if errorCode?has_content>
+      <div style="padding: 2px"><b>Error Log Number: </b>${errorCode}</div>
+      <#else>
       <div style="padding: 2px"><b>Error Message:</b> <#if status.message??>${status.message?html}<#else><i>&lt;Not specified&gt;</i></#if></div>
-      <div style="padding: 2px"><b>Server:</b> Alfresco ${server.edition?html} v${server.version?html} schema ${server.schema?html}</div>
-      <div style="padding: 2px"><b>Time:</b> ${date?datetime}</div>
+      </#if>
       <div style="padding: 2px"><b>Your request could not be processed at this time. Please contact your system administrator for further information.</b></div>
    </div>
 </div>

--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/errorcode.lib.ftl
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/errorcode.lib.ftl
@@ -1,0 +1,15 @@
+<#-- MNT-20195 (LM-190214): strip out and return error code from given error message. -->
+<#function getErrorCode message>
+   <#assign code = "">
+   
+   <#if message?? && message?is_string>
+      <!-- substring first 8 characters from message that usually be the error code id. -->
+      <#assign instanceId = message?substring(0, 8)>
+      <!-- check if these codes are 'numeric'. -->
+      <#if instanceId?matches("^[0-9]*$")>
+         <#assign code = instanceId>
+      </#if>
+   </#if>
+   
+   <#return code>
+</#function>

--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/modules/html.status.ftl
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/modules/html.status.ftl
@@ -1,6 +1,9 @@
 "'></a></script>
 <!-- above dodgy HTML is required to end any open tags, script etc. before further script injection -->
 
+<#-- MNT-20195 (LM-190214): import errorcode lib -->
+<#import "../errorcode.lib.ftl" as codeLib />
+
 <div class="theme-color-2" style="padding: 8px; margin: 8px; border: 1px dashed #D7D7D7;">
    <div style="font-weight: bold; font-size: 116%">
       <div style="padding: 2px">An error has occured in the Share component: ${url.service?html}.</div>
@@ -8,9 +11,13 @@
    </div>
    <div class="theme-color-4" style="padding-top:8px;">
       <div style="padding: 2px"><b>Error Code Information:</b> ${status.code} - ${status.codeDescription}</div>
+      <#-- MNT-20195 (LM-190214): hide server and time info, display error log number/error message. -->
+      <#assign errorCode = codeLib.getErrorCode(status.message)>
+      <#if errorCode?has_content>
+      <div style="padding: 2px"><b>Error Log Number: </b>${errorCode}</div>
+      <#else>
       <div style="padding: 2px"><b>Error Message:</b> <#if status.message??>${status.message?html}<#else><i>&lt;Not specified&gt;</i></#if></div>
-      <div style="padding: 2px"><b>Server:</b> Alfresco ${server.edition?html} v${server.version?html} schema ${server.schema?html}</div>
-      <div style="padding: 2px"><b>Time:</b> ${date?datetime}</div>
+      </#if>
       <div style="padding: 2px"><b>Your request could not be processed at this time. Please contact your system administrator for further information.</b></div>
    </div>
 </div>

--- a/share/src/main/webapp/testing/test.html
+++ b/share/src/main/webapp/testing/test.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
+                    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+   <head>
+      <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.9.1.css" type="text/css" media="screen" />
+      
+      <script type="text/javascript" src="https://code.jquery.com/jquery-1.8.1.min.js"></script>
+      <script type="text/javascript" src="https://code.jquery.com/qunit/qunit-2.9.1.js"></script>
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/json2/20160511/json2.min.js"></script>
+      
+      <script type="text/javascript" src="testVerboseInfoExposure.js"></script>
+      
+      <title>Test modules</title>
+      
+      <!-- Import your test modules -->
+      <script>
+      $(document).ready(function()
+      {
+         // start your test modules
+         testVerboseInfoExposure();
+      });
+      </script>
+   </head>
+   <body>
+      <div id="qunit"></div>
+      <div id="qunit-fixture"></div>
+   </body>
+</html>

--- a/share/src/main/webapp/testing/testVerboseInfoExposure.js
+++ b/share/src/main/webapp/testing/testVerboseInfoExposure.js
@@ -1,0 +1,158 @@
+/**
+ * MNT-20195 (LM-190214): test when error happened on webscript, will error code number being displayed.
+ * Also test when no error code thrown from exception, will proper error message being displayed.
+ */
+
+function isHTML(string)
+{
+   string = string && string.trim();
+   return (string && string.indexOf("<") == 0 && string.lastIndexOf(">") == string.length - 1);
+}
+
+function isJSON(string)
+{
+   string = string && string.trim();
+   return (string && string.indexOf("{") == 0 && string.lastIndexOf("}") == string.length - 1);
+}
+
+function isXML(string)
+{
+   string = string && string.trim();
+   return (string && string.indexOf("<?xml") == 0);
+}
+
+// get error log number
+function getErrorLogNumber(content)
+{
+   var logNumber = null;
+   if (isXML(content))
+   {
+      logNumber = getErrorLogNumberFromXML(content);
+   }
+   else if (isHTML(content))
+   {
+      logNumber = getErrorLogNumberFromHTML(content);
+   }
+   else if (isJSON(content))
+   {
+      logNumber = getErrorLogNumberFromJSON(content);
+   }
+   
+   return logNumber;
+}
+
+function getErrorLogNumberFromJSON(content)
+{
+   var response = JSON.parse(content);
+   return response.errorLogNumber;
+}
+
+function getErrorLogNumberFromXML(htmlString)
+{
+   var logNumber = null;
+   
+   var xml = $.parseXML(htmlString);
+   $(xml)
+      .find('errorLogNumber')
+      .each(function(index, element)
+      {
+         logNumber = element.innerHTML;
+         // break the loop
+         return false;
+      });
+   
+   return logNumber;
+}
+
+function getErrorLogNumberFromHTML(htmlString)
+{
+   var logNumber = null;
+   
+   var finder = (htmlString.indexOf("<td><b>Error Log Number") != -1) ? $(htmlString).find("table:contains('Error Log Number')") : $(htmlString).find("div:contains('Error Log Number')");
+   finder
+      .each(function(index, element)
+      {
+         var innerText = element.innerText;
+         var content = innerText.split("\n");
+         for (var i = 0, l = content.length; i < l; i++)
+         {
+            var text = content[i];
+            if (text && text.indexOf("Error Log Number") != -1)
+            {
+               text = text.trim();
+               logNumber = text.substring(text.length - 8);
+               return false;
+            }
+         }
+      });
+   
+   return logNumber;
+}
+
+function isValidNumber(number)
+{
+   return (number && !isNaN(number));
+}
+
+/**************************************** QUNIT TEST start ****************************************/
+
+function testVerboseInfoExposure()
+{
+   var searchUrl = "/share/proxy/alfresco/slingshot/node/search?q=PATH%3A%22%2F%22&lang=email&store=workspace%3A%2F%2FSpacesStore&maxResults=100";
+   var docDetailsUrl = "/share/page/document-details";
+   var authFinderUrl = "/share/service/components/people-finder/authority-finder?htmlid=FOOOO%A)F";
+   
+   /**
+    * Test if error message is displayed in FTL when unable to retrieve log number from exception nessage.
+    * - url: "/share/proxy/alfresco/slingshot/node/search?q=PATH%3A%22%2F%22&lang=email&store=workspace%3A%2F%2FSpacesStore&maxResults=100&alf_ticket=" + alfTicket,
+    */
+   QUnit.test("Test if error message is displayed in status template when no error log number returned in exception. (Test url = " + searchUrl + ")", function(assert)
+   {
+      var data = $.ajax(
+      {
+         async: false,
+         url: searchUrl,
+         type: "GET",
+         contentType: "application/json"
+      });
+      
+      var logNumber = null;
+      var message = null;
+      if (data && data.responseText)
+      {
+         var response = JSON.parse(data.responseText);
+         logNumber = response.errorLogNumber;
+         message = response.message;
+      }
+      
+      assert.ok(!isValidNumber(logNumber), "No error log number get: [" + logNumber + "]");
+      assert.ok(message, "Error message: " + message);
+   });
+   
+   /**
+    * Test if log number is displayed in Share FTL (i.e: html.status.ftl)
+    * - url: "/share/page/document-details"
+    * - url: "/share/service/components/people-finder/authority-finder?htmlid=FOOOO%A)F"
+    */
+   QUnit.test("Test if error log number can be displayed in correctly in Share status template (i.e: html.status.ftl).", function(assert)
+   {
+      var urls = [docDetailsUrl, authFinderUrl];
+      for (var i = 0, l = urls.length; i < l; i++)
+      {
+         var url = urls[i];
+         var data = $.ajax(
+         {
+            async: false,
+            url: url,
+            type: "GET"
+         });
+         
+         if (data && data.responseText)
+         {
+            logNumber = getErrorLogNumberFromHTML(data.responseText);
+         }
+         
+         assert.ok(isValidNumber(logNumber), "Error log number: " + logNumber + " (Test url = " + url + ")");
+      }
+   });
+}


### PR DESCRIPTION
There are a number of places in share where information about the underlying infrastructure is exposed through verbose error messages.

In the webscript FTL,
- display the error log id generated during exception, this will be the reference for the admin user to look in the log file.
- if error log id is not available, display the error message, but hide other unnecessary information exposure, like server and webscript versions.

QUnit tests added, url = http://localhost:8080/share/testing/test.html, but require to manual login to Share first.