### PR TITLE
Document list is cutted off in fullscreen mode

### DIFF
--- a/share/src/main/webapp/css/base.css
+++ b/share/src/main/webapp/css/base.css
@@ -1870,7 +1870,8 @@ body.brand-bg-1 .sticky-wrapper
 {
     margin: auto 0;
 }
-.alf-fullwindow .doclist .documents
+.alf-fullwindow .doclist .documents,
+.alf-fullscreen .doclist .documents
 {
     margin: 0 !important;
 }


### PR DESCRIPTION
**Steps to reproduce**:
1. Go to "My files".
2. Select "Full Screen" from "Options" menu

**Result**:
On the left side the view is moved 8 px over the screen.

**Solution**:
In the `base.css` file change:
```
.alf-fullwindow .doclist .documents
{
    margin: 0 !important;
}
```
to:
```
.alf-fullwindow .doclist .documents,
.alf-fullscreen .doclist .documents
{
    margin: 0 !important;
}
```

I think even better solution would be moving this rule to `components/documentlibrary/documentlist_v2.css` and removing `!important` declaration.

