### PR TITLE
ATS-345 : Build and push Share Docker images with Maven

### DIFF
--- a/packaging/docker/.maven-dockerignore
+++ b/packaging/docker/.maven-dockerignore
@@ -1,0 +1,1 @@
+target/docker/

--- a/packaging/docker/pom.xml
+++ b/packaging/docker/pom.xml
@@ -14,6 +14,10 @@
         <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>
         <!-- Alfresco GoogleDocs integration version -->
         <alfresco.googledocs.version>3.1.0</alfresco.googledocs.version>
+
+        <image.registry>quay.io</image.registry>
+        <image.name>alfresco/alfresco-share</image.name>
+        <image.tag>latest</image.tag>
     </properties>
 
     <dependencies>
@@ -127,5 +131,111 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>fabric8-maven-plugin</artifactId>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <skipBuildPom>false</skipBuildPom>
+                        <images>
+                            <!-- Default image configuration - used by the *local* and *intenal* profiles -->
+                            <image>
+                                <name>${image.name}:${image.tag}</name>
+                                <registry>${image.registry}</registry>
+                                <build>
+                                    <dockerFileDir>${project.basedir}</dockerFileDir>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>local</id>
+            <!-- Builds local image for development & testing only -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-image</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>internal</id>
+            <!-- Builds and publishes image to Quay -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-push-image</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <!-- Builds and publishes release image to Quay -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <configuration combine.self="override">
+                            <verbose>true</verbose>
+                            <skipBuildPom>false</skipBuildPom>
+                            <images>
+                                <image>
+                                    <name>${image.name}:${project.version}</name>
+                                    <registry>${image.registry}</registry>
+                                    <build>
+                                        <dockerFileDir>${project.basedir}</dockerFileDir>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>build-push-image</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -27,6 +27,18 @@
         <installer.version.name>${project.version}</installer.version.name>
 
     </properties>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>fabric8-maven-plugin</artifactId>
+                    <version>3.5.42</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
     <modules>
         <module>distribution</module>


### PR DESCRIPTION
First part of *ATS-345*:
- add `fabric8-maven-plugin` configurations for building and publishing the base `quay.io/alfresco-share` image
- add 3 separate profiles for different scenarios
    - build local docker image (`local` profile)
    - build & push docker image (`internal` profile, for the CI tool)
    - build & push the release docker image (`release` profile, also for the CI tool)

:warning: These changes are inactive at the moment, as the build plan wasn't yet changed. Once we have a green build, I'll activate the new Maven profiles.
:warning: When we'll merge these changes into the `master` branch, we'll also cherry-pick the commit into `support/SP/6.1.N`, `support/HF/6.1.0`, `support/SP/6.0.N` and `support/HF/6.0.1`.