### PR TITLE
Avoid build error: `[: !=: unary operator expected`

### DIFF
--- a/packaging/docker/substituter.sh
+++ b/packaging/docker/substituter.sh
@@ -16,7 +16,7 @@ sed -i -e 's/REPO_HOST:REPO_PORT/'"$REPO_HOST:$REPO_PORT"'/g' /usr/local/tomcat/
 echo "NEW -csrf.filter.referer is '$CSRF_FILTER_REFERER'"
 echo "NEW -csrf.filter.origin is '$CSRF_FILTER_ORIGIN'"
 
-if [ $CSRF_FILTER_REFERER != "" ] && [   $CSRF_FILTER_ORIGIN != "" ]; then
+if [[ $CSRF_FILTER_REFERER != "" ]] && [[ $CSRF_FILTER_ORIGIN != "" ]]; then
 # set CSRFPolicy to true and set both properties referer and origin
    sed -i -e "s|<config evaluator=\"string-compare\" condition=\"CSRFPolicy\" replace=\"false\">|<config evaluator=\"string-compare\" condition=\"CSRFPolicy\" replace=\"true\">|" /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml
    sed -i -e "s|<referer><\/referer>|<referer>$CSRF_FILTER_REFERER<\/referer>|" /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml


### PR DESCRIPTION
# Problem

Shellscript raises following error when using `docker-compose up` with [this](https://github.com/Alfresco/acs-community-deployment/blob/master/docker-compose/docker-compose.yml).

![image](https://user-images.githubusercontent.com/931554/54574155-9cbd9080-4a32-11e9-8828-c5ebd0b1aa1e.png)

This is NOT immediate NOR fatal problem, however, we have no reason to leave this uncool error.

Related: https://github.com/Alfresco/acs-community-deployment/pull/46