### PR TITLE
ATS-384 : Update AI amp version to 1.0.1

### DIFF
--- a/packaging/docker-aws/pom.xml
+++ b/packaging/docker-aws/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-ai-share</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <type>amp</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This change will be cherry-picked into the branches:
- **support/SP/6.1.N**
_and_
- **suport/HF/6.1.0**.

However, no new HF/SP are planned for this change only - we'll only check that the regular builds are still green.