### PR TITLE
MNT-20723 - small change to make authorization status columns appear by default for users

### DIFF
--- a/share/src/main/resources/alfresco/share-config.xml
+++ b/share/src/main/resources/alfresco/share-config.xml
@@ -129,7 +129,7 @@
          <!-- minimum length for username and password -->
          <username-min-length>2</username-min-length>
          <password-min-length>3</password-min-length>
-         <show-authorization-status>false</show-authorization-status>
+         <show-authorization-status>true</show-authorization-status>
       </users>
       <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
       <enable-external-users-panel>false</enable-external-users-panel>


### PR DESCRIPTION
Following the fix that went into MNT-20399, it meant that the auth status columns in the users listing in Share was set to no show by default - this small change puts that right.
This was as discussed in a Share triage call on Monday 8th July 2019