### PR TITLE
[SHA-2402] - Changed alfresco-core to 8.3 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency.httpcomponents.version>4.5.9</dependency.httpcomponents.version>
         <dependency.alfresco-repository.version>7.33.33</dependency.alfresco-repository.version>
         <dependency.alfresco-jlan.version>7.1</dependency.alfresco-jlan.version>
-        <dependency.alfresco-core.version>7.5.6</dependency.alfresco-core.version>
+        <dependency.alfresco-core.version>8.3</dependency.alfresco-core.version>
         <dependency.webscripts.version>7.11</dependency.webscripts.version>
         <dependency.surf.version>7.4</dependency.surf.version>
         <dependency.alfresco-sdk.version>2.0.0</dependency.alfresco-sdk.version>

--- a/share-services/pom.xml
+++ b/share-services/pom.xml
@@ -16,7 +16,24 @@
             <artifactId>alfresco-remote-api</artifactId>
             <version>7.34.16</version>
             <scope>provided</scope>
+            <exclusions>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.alfresco</groupId>
+            <artifactId>alfresco-core</artifactId>
+            <version>${dependency.alfresco-core.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency> 
 
         <!-- Events dependencies -->
         <dependency>
@@ -44,6 +61,10 @@
                     <groupId>dom4j</groupId>
                     <artifactId>dom4j</artifactId>
                 </exclusion>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -106,6 +106,13 @@
             <groupId>org.alfresco.surf</groupId>
             <artifactId>spring-surf-api</artifactId>
             <version>${dependency.surf.version}</version>
+            <exclusions>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+            </exclusions>
+            
         </dependency>
         <dependency>
             <groupId>org.alfresco.surf</groupId>
@@ -144,6 +151,11 @@
                     <groupId>org.jvnet.staxex</groupId>
                     <artifactId>stax-ex</artifactId>
                 </exclusion>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+                
             </exclusions>
         </dependency>
         <!-- Dependency on Alfresco patched version of Rhino available in artifacts.alfresco.com -->

--- a/wcmquickstart-module/wcmquickstartwebsite/pom.xml
+++ b/wcmquickstart-module/wcmquickstartwebsite/pom.xml
@@ -68,6 +68,10 @@
                      <groupId>dom4j</groupId>
                      <artifactId>dom4j</artifactId>
                  </exclusion>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
              </exclusions>
          </dependency>
 

--- a/web-editor-plugin/pom.xml
+++ b/web-editor-plugin/pom.xml
@@ -63,12 +63,28 @@
                      <groupId>dom4j</groupId>
                      <artifactId>dom4j</artifactId>
                  </exclusion>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
              </exclusions>
          </dependency>
         <dependency>
             <groupId>org.alfresco.surf</groupId>
             <artifactId>spring-webscripts</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.alfresco</groupId>
+            <artifactId>alfresco-core</artifactId>
+            <version>${dependency.alfresco-core.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency> 
+        
     </dependencies>
 
 </project>

--- a/web-editor-samples/customer-site/pom.xml
+++ b/web-editor-samples/customer-site/pom.xml
@@ -24,8 +24,23 @@
                     <groupId>dom4j</groupId>
                     <artifactId>dom4j</artifactId>
                 </exclusion>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.alfresco</groupId>
+            <artifactId>alfresco-core</artifactId>
+            <version>${dependency.alfresco-core.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>        
         <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>

--- a/web-editor/pom.xml
+++ b/web-editor/pom.xml
@@ -102,17 +102,34 @@
                     <groupId>dom4j</groupId>
                     <artifactId>dom4j</artifactId>
                 </exclusion>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+                
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco.surf</groupId>
             <artifactId>spring-webeditor</artifactId>
             <version>${dependency.surf.version}</version>
+            <exclusions>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco.surf</groupId>
             <artifactId>spring-webeditor-client-jsp</artifactId>
             <version>${dependency.surf.version}</version>
+            <exclusions>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.tuckey</groupId>

--- a/web-framework-commons/pom.xml
+++ b/web-framework-commons/pom.xml
@@ -26,8 +26,23 @@
                      <groupId>dom4j</groupId>
                      <artifactId>dom4j</artifactId>
                  </exclusion>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
              </exclusions>
          </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>alfresco-core</artifactId>
+            <version>${dependency.alfresco-core.version}</version>            
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>         
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
@@ -58,12 +73,24 @@
             <artifactId>alfresco-remote-api</artifactId>
             <version>7.34.16</version>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+            </exclusions>           
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -89,6 +116,13 @@
             <version>${dependency.alfresco-repository.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+            </exclusions>
+            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>
@@ -96,6 +130,12 @@
             <version>7.34.16</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco.surf</groupId>
@@ -103,6 +143,12 @@
             <version>${dependency.webscripts.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+		            <groupId>org.alfresco</groupId>
+		            <artifactId>alfresco-core</artifactId>
+	        	</exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
Since the vulnerability was corrected in the version 8.3 of the alfresco-core, it was needed to ensure that the share projects that are bringing in the alfresco-core library uses the 8.3 version and not older versions.