### PR TITLE
Added dependency management for jackson libraries (v2.10.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,8 @@
         <dependency.cxf.version>3.1.16</dependency.cxf.version>
         <dependency.beanutils.version>1.9.4</dependency.beanutils.version>
         <dependency.keycloak.version>8.0.1</dependency.keycloak.version>
-	      <dependency.apache.taglibs.version>1.2.3</dependency.apache.taglibs.version>
+        <dependency.apache.taglibs.version>1.2.3</dependency.apache.taglibs.version>
+        <dependency.jackson.version>2.10.2</dependency.jackson.version>
 
         <!-- Developer's runtime environment configuration -->
         <runtime.parent.folder>${basedir}/..</runtime.parent.folder>
@@ -268,6 +269,21 @@
               <groupId>org.apache.taglibs</groupId>
               <artifactId>taglibs-standard-jstlel</artifactId>
               <version>${dependency.apache.taglibs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${dependency.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${dependency.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${dependency.jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fix for vulnerabilities:
CVE-2018-14721
CVE-2018-14718
CVE-2018-14719
CVE-2018-19360
CVE-2018-19361
CVE-2018-19362
CVE-2019-14379
CVE-2019-14540
CVE-2019-16335
CVE-2019-16942
CVE-2019-16943
CVE-2019-17531
CVE-2019-17267
CVE-2018-5968
CVE-2018-12022
CVE-2018-12023
CVE-2019-12086
CVE-2019-14439