### PR TITLE
ATS-651 : AIS: Release Intelligence Services 1.1.2 (compatible with ACS 6.2.0)

### DIFF
--- a/packaging/docker-aws/pom.xml
+++ b/packaging/docker-aws/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-ai-share</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.2</version>
             <type>amp</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
   - Upgrading AIS to 1.1.2