### PR TITLE
Bumped hazelcast to version 2.4-20200303-alfresco-patched

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,17 @@
               <artifactId>commons-fileupload</artifactId>
 	      <version>1.4</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast</artifactId>
+                <version>2.4-20200303-alfresco-patched</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast-spring</artifactId>
+                <version>2.4-20200303-alfresco-patched</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -198,7 +198,6 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-spring</artifactId>
-            <version>2.4</version>
             <exclusions>
                 <exclusion>
                     <artifactId>hazelcast-client</artifactId>

--- a/share/src/main/resources/alfresco/web-extension/custom-slingshot-application-context.xml.sample
+++ b/share/src/main/resources/alfresco/web-extension/custom-slingshot-application-context.xml.sample
@@ -33,6 +33,12 @@
                <hz:interface>192.168.1.*</hz:interface>
             </hz:interfaces>
          </hz:network>
+
+         https://docs.hazelcast.org/docs/3.11/manual/html-single/index.html#untrusted-deserialization-protection
+         <hz:serialization>
+            <hz:java-serialization-filter defaults-disabled="true">
+            </hz:java-serialization-filter>
+         </hz:serialization>
       </hz:config>
    </hz:hazelcast>
    


### PR DESCRIPTION
Provided new config section https://docs.hazelcast.org/docs/3.11/manual/html-single/index.html#untrusted-deserialization-protection