### PR TITLE
GOOGLEDOCS-497: Updated pom.xml file to use 'GoogleDocs 3.2.0-RC3' (cherry-picked from master)

### DIFF
--- a/packaging/docker/pom.xml
+++ b/packaging/docker/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>
         <!-- Alfresco GoogleDocs integration version -->
-        <alfresco.googledocs.version>3.2.0-RC1</alfresco.googledocs.version>
+        <alfresco.googledocs.version>3.2.0-RC3</alfresco.googledocs.version>
 
         <image.registry>quay.io</image.registry>
         <image.name>alfresco/alfresco-share</image.name>


### PR DESCRIPTION
…herry-picked from master)