### PR TITLE
ACS-120 - Removed commons-lang that is being brought in transitively in alfresco-remote-api

### DIFF
--- a/share-services/pom.xml
+++ b/share-services/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-remote-api</artifactId>
-            <version>7.127</version>
+            <version>7.132</version>
             <scope>provided</scope>
             <exclusions>
             	<exclusion>
@@ -39,10 +39,6 @@
                     <artifactId>dom4j</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
         </dependency>
 
         <!-- Events dependencies -->
@@ -85,7 +81,7 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-remote-api</artifactId>
-            <version>7.127</version>
+            <version>7.132</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
 to avoid the -force option of the alfresco-mmt.jar