### PR TITLE
[MNT-20091] Added check to filter cm:taggable aspect with null

### DIFF
--- a/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/collaboration/tagQuery.get.js
+++ b/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/collaboration/tagQuery.get.js
@@ -49,6 +49,9 @@ function tagQuery()
    query += "ASPECT:\"{http://www.alfresco.org/model/content/1.0}taggable\"";
    //MNT-2118 Share inconsistencies when displaying locked files with tags
    query += " -ASPECT:\"{http://www.alfresco.org/model/content/1.0}workingcopy\"";
+
+   // MNT-20091 check to prevent cm:taggable with NULL
+   query += " AND ISNOTNULL:\"{http://www.alfresco.org/model/content/1.0}taggable\"";
    
    if (search.searchSubsystem.startsWith("solr"))
    {


### PR DESCRIPTION
I have added a new clause as described in issue, however, I would like to confirm the query that is being built is correct.

Example of query:

`PATH:"/app:company_home/app:shared//*"
AND ASPECT:{http://www.alfresco.org/model/content/1.0}taggable
-ASPECT:{http://www.alfresco.org/model/content/1.0}workingcopy
AND ISNOTNULL:{http://www.alfresco.org/model/content/1.0}taggable`

My question is, shouldn't exist an AND operator in the third clause? I'm getting more results than I would expect comparing with the same query using the AND operator. Just want to be sure I'm not missing something here.