### PR TITLE
ATS-761: Bump to AIS 1.2.0-A1

### DIFF
--- a/packaging/docker-aws/pom.xml
+++ b/packaging/docker-aws/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-ai-share</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.0-A1</version>
             <type>amp</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- note: for share-aws variant with AIS share amp pre-applied (pending 1.2.0-RC1 & final 1.2.0)