### PR TITLE
MNT-18448 MNT-19466: Reverting RTF and Visio extensions

### DIFF
--- a/share/src/main/resources/alfresco/slingshot-documentlibrary-context.xml
+++ b/share/src/main/resources/alfresco/slingshot-documentlibrary-context.xml
@@ -298,13 +298,6 @@
             <value>application/vnd.ms-excel.sheet.binary.macroenabled.12</value>
             <value>application/vnd.visio</value>
             <value>application/vnd.visio2013</value>
-            <value>application/vnd.ms-visio.drawing.macroenabled.main+xml</value>
-            <value>application/vnd.ms-visio.drawing.main+xml</value>
-            <value>application/vnd.ms-visio.stencil.macroenabled.main+xml</value>
-            <value>application/vnd.ms-visio.stencil.main+xml</value>
-            <value>application/vnd.ms-visio.template.macroenabled.main+xml</value>
-            <value>application/vnd.ms-visio.template.main+xml</value>
-            <value>application/rtf</value>
          </list>
       </property>
    </bean>
@@ -350,13 +343,6 @@
             <value>application/vnd.ms-powerpoint.slide.macroEnabled.12</value>
             <value>application/vnd.visio</value>
             <value>application/vnd.visio2013</value>
-            <value>application/vnd.ms-visio.drawing.macroEnabled.main+xml</value>
-            <value>application/vnd.ms-visio.drawing.main+xml</value>
-            <value>application/vnd.ms-visio.stencil.macroenabled.main+xml</value>
-            <value>application/vnd.ms-visio.stencil.main+xml</value>
-            <value>application/vnd.ms-visio.template.macroenabled.main+xml</value>
-            <value>application/vnd.ms-visio.template.main+xml</value
-            <value>application/rtf</value>
          </list>
       </property>
    </bean>

--- a/share/src/main/webapp/components/documentlibrary/actions.js
+++ b/share/src/main/webapp/components/documentlibrary/actions.js
@@ -657,8 +657,6 @@
          "application/vnd.ms-word.document.macroenabled.12": "Word.Document",
          "application/vnd.openxmlformats-officedocument.wordprocessingml.template": "Word.Document",
          "application/vnd.ms-word.template.macroenabled.12": "Word.Document",
-         "application/rtf":"Word.Document",
-
 
          "application/vnd.ms-powerpoint": "PowerPoint.Slide",
          "application/vnd.openxmlformats-officedocument.presentationml.presentation": "PowerPoint.Slide",
@@ -679,13 +677,7 @@
          "application/vnd.ms-excel.addin.macroenabled.12": "Excel.Sheet",
          "application/vnd.ms-excel.sheet.binary.macroenabled.12": "Excel.Sheet",
          "application/vnd.visio": "Visio.Drawing",
-         "application/vnd.visio2013": "Visio.Drawing",
-         "application/vnd.ms-visio.drawing.macroenabled.main+xml": "Visio.Drawing",
-         "application/vnd.ms-visio.drawing.main+xml": "Visio.Drawing",
-         "application/vnd.ms-visio.stencil.macroenabled.main+xml": "Visio.Drawing",
-         "application/vnd.ms-visio.stencil.main+xml": "Visio.Drawing",
-         "application/vnd.ms-visio.template.macroenabled.main+xml": "Visio.Drawing",
-         "application/vnd.ms-visio.template.main+xml": "Visio.Drawing"
+         "application/vnd.visio2013": "Visio.Drawing"
 
       },
 
@@ -802,18 +794,7 @@
                docm: "application/vnd.ms-word.document.macroenabled.12",
                dotx: "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
                dotm: "application/vnd.ms-word.template.macroenabled.12",
-               rtf: "application/rtf",
               
-               vsd: "application/vnd.visio",
-               vss: "application/vnd.visio",
-               vst: "application/vnd.visio",
-               vsdx: "application/vnd.ms-visio.drawing.main+xml",
-               vsdm: "application/vnd.ms-visio.drawing.macroenabled.main+xml",
-               vssx: "application/vnd.ms-visio.stencil.main+xml",
-               vssm: "application/vnd.ms-visio.stencil.macroenabled.main+xml",
-               vstx: "application/vnd.ms-visio.template.main+xml",
-               vstm: "application/vnd.ms-visio.template.macroenabled.main+xml",
-               
                ppt: "application/vnd.ms-powerpoint",
                pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
                pptm: "application/vnd.ms-powerpoint.presentation.macroenabled.12",
@@ -921,7 +902,6 @@
             'dot'  : 'ms-word',
             'dotx' : 'ms-word',
             'dotm' : 'ms-word',
-            'rtf'  : 'ms-word',
             'xls'  : 'ms-excel',
             'xlsx' : 'ms-excel',
             'xlsb' : 'ms-excel',
@@ -1287,18 +1267,6 @@
             'dot'  : 'ms-word',
             'dotx' : 'ms-word',
             'dotm' : 'ms-word',
-            'rtf'  : 'ms-word',
-
-           'vsd': 'ms-visio',
-            'vss': 'ms-visio',
-            'vst': 'ms-visio',
-            'vsdx': 'ms-visio',
-            'vsdm': 'ms-visio',
-            'vssx': 'ms-visio',
-            'vssm': 'ms-visio',
-            'vstx': 'ms-visio',
-            'vstm': 'ms-visio',
-
             'xls'  : 'ms-excel',
             'xlsx' : 'ms-excel',
             'xlsb' : 'ms-excel',


### PR DESCRIPTION
It has been decided not to include these changes (rtf, visio) in master and 6.2.N code line, reverting them for now. They've been added to 5.2.7 and 5.2.N.