### PR TITLE
APPS-212: Make sure that sslRequired won't be set with an invalid value

### DIFF
--- a/share/src/main/java/org/alfresco/web/site/servlet/config/AIMSConfig.java
+++ b/share/src/main/java/org/alfresco/web/site/servlet/config/AIMSConfig.java
@@ -93,7 +93,7 @@ public class AIMSConfig
             methodName = "set" + StringUtils.capitalize(configElement.getKey());
 
             // Skip null or empty values
-            if (value == null || value.isEmpty())
+            if (value == null)
             {
                 continue;
             }
@@ -107,12 +107,19 @@ public class AIMSConfig
                     {
                         if (method.getParameterTypes()[0] == String.class)
                         {
-                            // Special case of ssl-required; make sure we don't set an invalid value
-                            if (methodName.equals("setSslRequired"))
+                            try
                             {
-                                SslRequired.valueOf(value.toUpperCase());
+                                // Special case of ssl-required; make sure we don't set an invalid value
+                                if (methodName.equals("setSslRequired"))
+                                {
+                                    SslRequired.valueOf(value.toUpperCase());
+                                }
+                                method.invoke(this.adapterConfig, value);
                             }
-                            method.invoke(this.adapterConfig, value);
+                            catch (IllegalArgumentException e)
+                            {
+                                method.invoke(this.adapterConfig, SslRequired.EXTERNAL.toString().toLowerCase());
+                            }
                         }
                         else if (method.getParameterTypes()[0] == boolean.class)
                         {
@@ -120,7 +127,7 @@ public class AIMSConfig
                         }
                     }
                 }
-                catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e)
+                catch (InvocationTargetException | IllegalAccessException e)
                 {
                     logger.debug(e.getMessage());
                 }

--- a/share/src/main/resources/share-config.properties
+++ b/share/src/main/resources/share-config.properties
@@ -1,9 +1,9 @@
-#Properties for AIMS 
+# Properties for AIMS
 aims.enabled=false
 aims.realm=
 aims.resource=
 aims.authServerUrl=
-aims.sslRequired=none
+aims.sslRequired=external
 aims.publicClient=
 aims.autodetectBearerOnly=
 aims.alwaysRefreshToken=

--- a/share/src/main/resources/share-config.properties
+++ b/share/src/main/resources/share-config.properties
@@ -7,5 +7,5 @@ aims.sslRequired=external
 aims.publicClient=
 aims.autodetectBearerOnly=
 aims.alwaysRefreshToken=
-aims.principalAttribute=email
+aims.principalAttribute=sub
 aims.enableBasicAuth=

--- a/share/src/test/resources/alfresco/module/shareProperties/share-config.properties
+++ b/share/src/test/resources/alfresco/module/shareProperties/share-config.properties
@@ -1,11 +1,11 @@
-#Properties for AIMS 
-aims.enabled=
+# Properties for AIMS
+aims.enabled=false
 aims.realm=
 aims.resource=
 aims.authServerUrl=
-aims.sslRequired=
+aims.sslRequired=external
 aims.publicClient=
 aims.autodetectBearerOnly=
 aims.alwaysRefreshToken=
-aims.principalAttribute=
+aims.principalAttribute=sub
 aims.enableBasicAuth=


### PR DESCRIPTION
Make sure that sslRequired won't be set with an invalid value
Prepared the AIMSConfig for the rest of the Keycloack configurable values.
Set share config.properties file to default Keycloack values.
Added more unit tests.