### PR TITLE
MNT-21660 - added annotation type to filter for dashlet

### DIFF
--- a/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/filters.lib.js
+++ b/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/filters.lib.js
@@ -20,7 +20,8 @@ var Filters =
       "fm:forums",
       "fm:forum",
       "fm:topic",
-      "fm:post"
+      "fm:post",
+      "oa:annotation"
    ],
 
    /**


### PR DESCRIPTION
This is for MNT-21660 - AEV annotation objects appearing in the 'My Documents' dashlet