### PR TITLE
SFDCENG-850: Fix for Salesforce

### DIFF
--- a/share/src/main/java/org/alfresco/web/site/servlet/AIMSFilter.java
+++ b/share/src/main/java/org/alfresco/web/site/servlet/AIMSFilter.java
@@ -214,11 +214,12 @@ public class AIMSFilter extends KeycloakOIDCFilter
                 credentials.setProperty(Credentials.CREDENTIAL_USERNAME, username);
                 vault.store(credentials);
 
+                // Inform the Slingshot login controller of a successful login attempt as further processing may be required ?
+                this.loginController.beforeSuccess(request, response);
+
                 // Initialise the user metadata object used by some web scripts
                 this.initUser(request);
 
-                // Inform the Slingshot login controller of a successful login attempt as further processing may be required ?
-                this.loginController.beforeSuccess(request, response);
             }
             else
             {

--- a/share/src/main/webapp/WEB-INF/web.xml
+++ b/share/src/main/webapp/WEB-INF/web.xml
@@ -6,12 +6,12 @@
 
    <display-name>Alfresco Project Slingshot</display-name>
    <description>Alfresco Project Slingshot application</description>
-
+   
    <context-param>
       <param-name>org.jboss.jbossfaces.WAR_BUNDLES_JSF_IMPL</param-name>
       <param-value>true</param-value>
    </context-param>
-
+   
    <!-- Spring Application Context location and context class -->
    <context-param>
       <description>Spring config file location</description>
@@ -24,7 +24,7 @@
       <filter-name>MTAuthentationFilter</filter-name>
       <filter-class>org.alfresco.web.site.servlet.MTAuthenticationFilter</filter-class>
    </filter>
-
+   
    <filter>
       <description>Redirects view and service URLs to the dispatcher servlet.</description>
       <filter-name>UrlRewriteFilter</filter-name>
@@ -40,7 +40,7 @@
          <param-value>/page/sfdc/canvas/signedrequest</param-value>
       </init-param>
    </filter>
-
+   
    <filter>
       <description>Share SSO authentication support filter.</description>
       <filter-name>Authentication Filter</filter-name>
@@ -188,7 +188,7 @@
    <listener>
       <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
    </listener>
-
+   
    <servlet>
       <servlet-name>Spring Surf Dispatcher Servlet</servlet-name>
       <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
@@ -202,7 +202,7 @@
       </init-param>
       <load-on-startup>1</load-on-startup>
    </servlet>
-
+   
    <servlet-mapping>
       <servlet-name>Spring Surf Dispatcher Servlet</servlet-name>
       <url-pattern>/page/*</url-pattern>
@@ -211,7 +211,7 @@
       <servlet-name>Spring Surf Dispatcher Servlet</servlet-name>
       <url-pattern>/p/*</url-pattern>
    </servlet-mapping>
-
+   
    <session-config>
       <session-timeout>60</session-timeout>
    </session-config>
@@ -220,10 +220,10 @@
    <welcome-file-list>
       <welcome-file>index.jsp</welcome-file>
    </welcome-file-list>
-
-   <error-page>
-      <error-code>500</error-code>
-      <location>/error500.jsp</location>
+   
+   <error-page> 
+      <error-code>500</error-code> 
+      <location>/error500.jsp</location> 
    </error-page>
 
 </web-app>

--- a/share/src/main/webapp/WEB-INF/web.xml
+++ b/share/src/main/webapp/WEB-INF/web.xml
@@ -6,12 +6,12 @@
 
    <display-name>Alfresco Project Slingshot</display-name>
    <description>Alfresco Project Slingshot application</description>
-   
+
    <context-param>
       <param-name>org.jboss.jbossfaces.WAR_BUNDLES_JSF_IMPL</param-name>
       <param-value>true</param-value>
    </context-param>
-   
+
    <!-- Spring Application Context location and context class -->
    <context-param>
       <description>Spring config file location</description>
@@ -24,7 +24,7 @@
       <filter-name>MTAuthentationFilter</filter-name>
       <filter-class>org.alfresco.web.site.servlet.MTAuthenticationFilter</filter-class>
    </filter>
-   
+
    <filter>
       <description>Redirects view and service URLs to the dispatcher servlet.</description>
       <filter-name>UrlRewriteFilter</filter-name>
@@ -35,8 +35,12 @@
    <filter>
       <filter-name>AIMS Filter</filter-name>
       <filter-class>org.alfresco.web.site.servlet.AIMSFilter</filter-class>
+      <init-param>
+         <param-name>keycloak.config.skipPattern</param-name>
+         <param-value>/page/sfdc/canvas/signedrequest</param-value>
+      </init-param>
    </filter>
-   
+
    <filter>
       <description>Share SSO authentication support filter.</description>
       <filter-name>Authentication Filter</filter-name>
@@ -184,7 +188,7 @@
    <listener>
       <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
    </listener>
-   
+
    <servlet>
       <servlet-name>Spring Surf Dispatcher Servlet</servlet-name>
       <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
@@ -198,7 +202,7 @@
       </init-param>
       <load-on-startup>1</load-on-startup>
    </servlet>
-   
+
    <servlet-mapping>
       <servlet-name>Spring Surf Dispatcher Servlet</servlet-name>
       <url-pattern>/page/*</url-pattern>
@@ -207,7 +211,7 @@
       <servlet-name>Spring Surf Dispatcher Servlet</servlet-name>
       <url-pattern>/p/*</url-pattern>
    </servlet-mapping>
-   
+
    <session-config>
       <session-timeout>60</session-timeout>
    </session-config>
@@ -216,10 +220,10 @@
    <welcome-file-list>
       <welcome-file>index.jsp</welcome-file>
    </welcome-file-list>
-   
-   <error-page> 
-      <error-code>500</error-code> 
-      <location>/error500.jsp</location> 
+
+   <error-page>
+      <error-code>500</error-code>
+      <location>/error500.jsp</location>
    </error-page>
 
 </web-app>

--- a/share/src/main/webapp/WEB-INF/web.xml
+++ b/share/src/main/webapp/WEB-INF/web.xml
@@ -35,10 +35,6 @@
    <filter>
       <filter-name>AIMS Filter</filter-name>
       <filter-class>org.alfresco.web.site.servlet.AIMSFilter</filter-class>
-      <init-param>
-         <param-name>keycloak.config.skipPattern</param-name>
-         <param-value>/page/sfdc/canvas/signedrequest</param-value>
-      </init-param>
    </filter>
    
    <filter>


### PR DESCRIPTION
`this.loginController.beforeSuccess(request, response)` puts in session the **_alf_USER_GROUPS** attribute which contains the groups that the user logged in is a member of.
I discovered that `this.initUser(request)` from AIMSFilter after many debug steps invokes `loadUser` from SlingshotUserFactory which looks in the session for **_alf_USER_GROUPS** attribute and sets the value of it as a property of the logged in user called **alfUserGroups**. This property is used in WebScripts using `user.properties["alfUserGroups"].split(,)` to get an array of the groups that the user is a member of. 

*Current behaviour*:  `this.initUser(request)` from AIMSFilter is looking for **_alf_USER_GROUPS** which is null and then `this.loginController.beforeSuccess(request, response)` puts in session the **_alf_USER_GROUPS** attribute.
That's why these commands need to run in reverse order.