### PR TITLE
ATS-808: Bump AIS to 1.2.1-RC2

### DIFF
--- a/packaging/docker-aws/pom.xml
+++ b/packaging/docker-aws/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-ai-share</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1-RC2</version>
             <type>amp</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- AIS service pack - targeting ACS 6.2.2 (as part of S/H release train)