### PR TITLE
[MNT-20006] Redirect a user to the document location instead of site location when the user is not member of the site

### DIFF
--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/node-details/node-header.get.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/node-details/node-header.get.js
@@ -2,12 +2,12 @@
 
 /**
  * Gets icon resource URL for specified {node} parameter.
- * 
+ *
  * The URL is composed by {url.context} + "/res/" +
- *  - icon resource string path from {style} configuration that corresponds with matching filter from 
- *     share-documentlibrary-config.xml [CommonComponentStyle][component-style], {browse.folder} component 
+ *  - icon resource string path from {style} configuration that corresponds with matching filter from
+ *     share-documentlibrary-config.xml [CommonComponentStyle][component-style], {browse.folder} component
  *  - "components/images/filetypes/generic-folder-48.png" if there are no matching filters.
- * 
+ *
  * @param node
  * @returns icon resource URL for specified {node} parameter.
  */
@@ -64,6 +64,10 @@ function main()
       model.commentCount = (count != undefined ? count : null);
       model.lock = (nodeDetails.item.node.properties["cm:lockType"] != undefined ? nodeDetails.item.node.properties["cm:lockType"] : null);
 
+      // MNT-20006, verifies if user has access to a document located in a certain site where is not a member
+      var siteMembership = model.site != null ? AlfrescoUtil.getSiteMembership(model.site) : null;
+      model.notSiteMemberWithPermissions = (model.site != null && siteMembership != null && siteMembership.isMember == false).toString();
+
       var suppressConfig = AlfrescoUtil.getSupressConfig();
       var supressDateFolderDetailsConfig = {};
       if (suppressConfig)
@@ -71,8 +75,8 @@ function main()
          supressDateFolderDetailsConfig = JSON.parse(suppressConfig).date.details.folder;
       }
       var supressDate = AlfrescoUtil.isComponentSuppressed(nodeDetails.item.node, supressDateFolderDetailsConfig);
-      
-      model.showItemModifier = (!supressDate).toString(); 
+
+      model.showItemModifier = (!supressDate).toString();
 
       // Widget instantiation metadata...
       var likes = {};
@@ -108,10 +112,11 @@ function main()
             libraryRoot: model.libraryRoot,
             lock: model.lock,
             folderIcon: model.folderIcon,
-            showItemModifier: (model.showItemModifier == "true")
+            showItemModifier: (model.showItemModifier == "true"),
+            notSiteMemberWithPermissions: (model.notSiteMemberWithPermissions == "true")
          }
       };
-      
+
       if(nodeDetails.item.workingCopy != null && nodeDetails.item.workingCopy.isWorkingCopy)
       {
          nodeHeader.options.showFavourite = false;
@@ -119,7 +124,7 @@ function main()
          model.showQuickShare = "false";
          model.showComments = "false";
       }
-      
+
       model.widgets = [nodeHeader];
    }
 }

--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/node-details/node-header.get.properties
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/components/node-details/node-header.get.properties
@@ -16,3 +16,4 @@ banner.not-found=The item cannot be found. Either you do not have permissions to
 message.document.moved=This document is now located in site {0}. We will redirect you to this site shortly.
 message.document.moved.repo=This document is now located in repository folder. We will redirect you to this folder shortly.
 message.document.movedToRepo=This document has been moved out of the site. We will redirect you to its new location shortly.
+message.document.notSiteMember=This document is located in a site that you are not member of. We will redirect you to its direct location shortly.

--- a/share/src/main/webapp/components/node-details/node-header.js
+++ b/share/src/main/webapp/components/node-details/node-header.js
@@ -55,21 +55,21 @@
       {
          /**
           * Current page context, if any (e.g. "mine", "shared" - as extracted from URI template)
-          * 
+          *
           * @property pagecontext
           * @type string
           * @default null
           */
          pagecontext: null,
-         
+
          /**
-          * 
+          *
           * @property libraryRoot
           * @type string
           * @default null
           */
          libraryRoot: null,
-         
+
          /**
           * Reference to the current document
           *
@@ -114,13 +114,13 @@
 
          /**
           * Show only the location. Overrides the other option settings.
-          * 
+          *
           * @property showOnlyLocation
           * @type boolean
           * @default false
           */
          showOnlyLocation: false,
-         
+
          /**
           * Flag indicating whether or not to show favourite
           *
@@ -211,12 +211,22 @@
 
          /**
           * Flag indicating whether or not to show item modifier
-          * 
+          *
           * @property showItemModifier
           * @type boolean
           * @default: true
           */
-         showItemModifier: true
+         showItemModifier: true,
+
+         /**
+          * Flag indicating if user is not a member of the site where item belongs
+          * but has permissions on the item itself
+          *
+          * @property notSiteMemberWithPermissions
+          * @type boolean
+          * @default: false
+          */
+         notSiteMemberWithPermissions: false
       },
 
       /**
@@ -227,14 +237,36 @@
        */
       onReady: function NodeHeader_onReady()
       {
+          // MNT-20006, redirect non member user (but with collaborator permissions) to the document direct location instead of site location
+          if (this.options.notSiteMemberWithPermissions === true)
+          {
+            var correctUrl = "/share/page/document-details?nodeRef=" + this.options.nodeRef;
+            Alfresco.util.PopupManager.displayPrompt(
+            {
+               text: this.msg("message.document.notSiteMember"),
+               buttons: [
+               {
+                  text: this.msg("button.ok"),
+                  handler: function()
+                  {
+                     window.location = correctUrl;
+                  },
+                  isDefault: true
+               }]
+            });
+            YAHOO.lang.later(10000, this, function()
+            {
+              window.location = correctUrl;
+            });
+          }
           // MNT-9081 fix, redirect user to the correct location, if requested site is not the actual site where document is located
-          if (this.options.siteId != this.options.actualSiteId)
+          else if (this.options.siteId != this.options.actualSiteId)
           {
              // Moved to a site...
              if (this.options.actualSiteId != null)
              {
                 var inRepository = this.options.actualSiteId === null,
-                    correctUrl = window.location.protocol + "//" + window.location.host + Alfresco.constants.URL_PAGECONTEXT + 
+                    correctUrl = window.location.protocol + "//" + window.location.host + Alfresco.constants.URL_PAGECONTEXT +
                           (inRepository ? "" : "site/" + this.options.actualSiteId + "/") + "document-details" + window.location.search;
                 Alfresco.util.PopupManager.displayPrompt(
                 {
@@ -313,7 +345,7 @@
                      displayName: this.options.displayName
                   }).display(this.options.sharedId, this.options.sharedBy);
          }
-         
+
          // Parse the date
          if (this.options.showItemModifier && !this.options.showOnlyLocation)
          {
@@ -338,7 +370,7 @@
          var url = 'components/node-details/node-header?nodeRef={nodeRef}&rootPage={rootPage}' +
             '&rootLabelId={rootLabelId}&showFavourite={showFavourite}&showLikes={showLikes}' +
             '&showComments={showComments}&showQuickShare={showQuickShare}&showDownload={showDownload}&showPath={showPath}&showItemModifier={showItemModifier}' +
-            (this.options.pagecontext ? '&pagecontext={pagecontext}' :  '') + 
+            (this.options.pagecontext ? '&pagecontext={pagecontext}' :  '') +
             (this.options.libraryRoot ? '&libraryRoot={libraryRoot}' :  '') +
             (this.options.siteId ? '&site={siteId}' :  '');
 


### PR DESCRIPTION
This PR has been created for MNT-20006 which contains the analysis made so far. This PR is an alternative for #364

The use case:

1. Create private site
2. Upload a document to private site
3. Put an user who is not member of the site as document collaborator
4. With the non member user, search for the document, click the result
5. The document opens with site location
6. The post activity operation fails when opening the document details page
7. Click "edit metadata" option
8. The page doesn't open, showing the error page instead

When the document is accessed by site URL (/share/page/site/{site_name}/document-details?nodeRef...), there is a request to update the site activity which fails since the user is not member of the site. Additionally, when trying to edit metadata, this page also fails.

When the document is accessed by direct document URL (/share/page/document-details?nodeRef...), everything work as expected but the activity is not registered (since the site location is not used).

This PR has a proposal which detects if user is member of the site where document is located, if is not a member, the user is redirected to the document direct location.