### PR TITLE
Resolving the problem of the warning claiming the same version between share and share services

### DIFF
--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/share/imports/share-header.lib.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/share/imports/share-header.lib.js
@@ -60,6 +60,10 @@ function getShareVersion() {
    return shareManifest.getSpecificationVersion();
 }
 
+function getShareImplementationVersion() {
+   return shareManifest.getImplementationVersion();
+}
+
 /* *********************************************************************************
  *                                                                                 *
  * USER GROUP INFO                                                                 *
@@ -1780,7 +1784,7 @@ function getHeaderModel(pageTitle) {
       name: "share/services/ServicesWarning",
       config: {
          shareServices: getShareServices(),
-         shareVersion: getShareVersion(),
+         shareVersion: getShareImplementationVersion(),
          userIsAdmin: user.isAdmin
       }
    },


### PR DESCRIPTION
The change in here introduce a new method to read from the manifest file in share service the same version used in share in order to have an aligned comparision between versions. This warning raised after fixing the versioning in share service.