### PR TITLE
[MNT-21654] Added validation to check if cm:lastThumbnailModification property exists

### DIFF
--- a/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/item.lib.ftl
+++ b/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/item.lib.ftl
@@ -57,11 +57,13 @@
    "modifiedBy": "${modifiedBy}",
    "modifiedByUser": "${modifiedByUser}",
    <#if node.hasAspect("{http://www.alfresco.org/model/content/1.0}thumbnailModification")>
-      <#list node.properties.lastThumbnailModification as thumbnailMod>
+     <#if node.properties.lastThumbnailModification??>
+       <#list node.properties.lastThumbnailModification as thumbnailMod>
          <#if thumbnailMod?contains("doclib")>
    "lastThumbnailModification": "${thumbnailMod}",
          </#if>
-      </#list>
+       </#list>
+     </#if>
    </#if>
    "lockedBy": "${lockedBy}",
    "lockedByUser": "${lockedByUser}",


### PR DESCRIPTION
Prevents an error to happen if for some reason there are nodes without the property cm:lastThumbnailModification, making the "My Documents" dashlet listing these nodes.