### PR TITLE
feature/APPS-758: Temporarily disabled white source travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,12 +68,12 @@ jobs:
       before_install: bash _ci/init.sh
       script: bash _ci/build.sh
 
-    - name: "White Source"
-      stage: build
-      # only on SP branches or master and if it is not a PR
-      if: fork = false AND (branch = develop OR branch =~ /support\/SP\/.*/ OR branch =~ /.*\/APPS-.*$/) AND type != pull_request
-      before_install: bash _ci/init.sh
-      script: travis_wait 30 bash _ci/whitesource.sh _ci/.wss-unified-agent.config
+#    - name: "White Source"
+#      stage: build
+#      # only on SP branches or master and if it is not a PR
+#      if: fork = false AND (branch = develop OR branch =~ /support\/SP\/.*/ OR branch =~ /.*\/APPS-.*$/) AND type != pull_request
+#      before_install: bash _ci/init.sh
+#      script: travis_wait 30 bash _ci/whitesource.sh _ci/.wss-unified-agent.config
 
     - name: "Source Clear Scan (SCA)"
       stage: build


### PR DESCRIPTION
Because of license expiration in January 2021, is required to stop using whitesource code scan.
In order to continue to receive feedback from tests stage we need to temporarily commented this job.