### PR TITLE
APPS-694: Added ACS with Share Services submodule

### DIFF
--- a/_ci/build.sh
+++ b/_ci/build.sh
@@ -17,9 +17,16 @@ mvn -B -q install \
 
 
 #build image
-cd packaging/docker
+cd ${TRAVIS_BUILD_DIR}/packaging/docker
 mvn install -Plocal
 mvn fabric8:push
+
+if [ $TRAVIS_BRANCH != "master" ]; then
+  #build enterprise repo with share services image
+  cd ${TRAVIS_BUILD_DIR}/packaging/docker-acs-share-services/enterprise
+  mvn install -Plocal
+  mvn fabric8:push
+fi
 
 popd
 set +vex

--- a/packaging/distribution/pom.xml
+++ b/packaging/distribution/pom.xml
@@ -1,13 +1,17 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+    <artifactId>alfresco-content-services-share-distribution</artifactId>
+    <name>Distribution of Alfresco Share</name>
+    <packaging>pom</packaging>
+
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-share-packaging</artifactId>
         <version>7.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>alfresco-content-services-share-distribution</artifactId>
-    <name>Distribution of Alfresco Share</name>
-    <packaging>pom</packaging>
 
     <!-- To replace in share-config-custom.xml -->
     <properties>
@@ -42,6 +46,7 @@
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
             </resource>
+
             <resource>
                 <directory>${project.build.directory}/dependency/bitrock/bitrock/alfresco/shared/web-extension</directory>
                 <targetPath>${project.build.outputDirectory}/web-extension-samples</targetPath>
@@ -67,6 +72,7 @@
                             <useDefaultDelimiters>false</useDefaultDelimiters>
                         </configuration>
                     </execution>
+
                     <execution>
                         <id>copy-resources</id>
                         <phase>process-resources</phase>
@@ -108,27 +114,6 @@
                         </configuration>
                     </execution>
 
-                    <!-- Extract licenses and bin from distribution resources 
-					Assuming this is not necessary for ACS 6.0+
-                    <execution>
-                        <id>unpack-resources</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.alfresco</groupId>
-                                    <artifactId>alfresco-platform-community-distributionzip</artifactId>
-                                    <version>${alfresco.platform.version}</version>
-                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                                    <includes>bin/**,licenses/**</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
--->
                     <!-- Copy MMT jar -->
                     <execution>
                         <id>fetch-resources</id>
@@ -141,7 +126,7 @@
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-mmt</artifactId>
-                                    <version>6.0</version>
+                                    <version>${dependency.alfresco-mmt.version}</version>
                                     <outputDirectory>${project.build.outputDirectory}/bin</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
@@ -153,7 +138,7 @@
 
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                 <executions>
+                <executions>
                     <execution>
                         <id>package-share</id>
                         <phase>package</phase>

--- a/packaging/docker-acs-share-services/.maven-dockerignore
+++ b/packaging/docker-acs-share-services/.maven-dockerignore
@@ -1,0 +1,1 @@
+target/docker/

--- a/packaging/docker-acs-share-services/community/Dockerfile
+++ b/packaging/docker-acs-share-services/community/Dockerfile
@@ -1,0 +1,39 @@
+# Fetch image of ACS Community Edition
+FROM alfresco/alfresco-community-repo-base:latest
+
+USER root
+
+# Set default Docker context
+ARG RESOURCE_PATH=target
+
+# Set default environment args
+ARG GROUPNAME=Alfresco
+ARG IMAGEUSERNAME=alfresco
+ARG TOMCAT_DIR=/usr/local/tomcat
+
+# Clean previous amps
+RUN rm ${TOMCAT_DIR}/amps/*
+
+# Copy the amps from build context to the appropriate location for your application server
+COPY ${RESOURCE_PATH}/amps ${TOMCAT_DIR}/amps
+
+RUN chgrp -R ${GROUPNAME} ${TOMCAT_DIR}/amps && \
+    chmod 664 ${TOMCAT_DIR}/amps/alfresco-share-services-*.amp
+
+# Remove installed amps
+RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar uninstall \
+    org.alfresco.integrations.google.docs \
+    ${TOMCAT_DIR}/webapps/alfresco
+RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar uninstall \
+    alfresco-aos-module \
+    ${TOMCAT_DIR}/webapps/alfresco
+
+# Apply Share Services amp
+RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar install \
+    ${TOMCAT_DIR}/amps \
+    ${TOMCAT_DIR}/webapps/alfresco -directory -nobackup -force
+
+EXPOSE 8000
+
+USER ${IMAGEUSERNAME}
+

--- a/packaging/docker-acs-share-services/community/pom.xml
+++ b/packaging/docker-acs-share-services/community/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>acs-community-docker-share-services</artifactId>
+    <name>Alfresco Content Services (Community) Docker With Share Services image builder</name>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>org.alfresco</groupId>
+        <artifactId>acs-docker-share-services</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <image.name>alfresco/alfresco-content-repository-share-services-community</image.name>
+    </properties>
+</project>

--- a/packaging/docker-acs-share-services/community/pom.xml
+++ b/packaging/docker-acs-share-services/community/pom.xml
@@ -15,5 +15,6 @@
 
     <properties>
         <image.name>alfresco/alfresco-content-repository-share-services-community</image.name>
+        <license-header-location>${project.parent.parent.parent.basedir}</license-header-location>
     </properties>
 </project>

--- a/packaging/docker-acs-share-services/enterprise/Dockerfile
+++ b/packaging/docker-acs-share-services/enterprise/Dockerfile
@@ -1,0 +1,39 @@
+# Fetch image of ACS Enterprise Edition
+FROM quay.io/alfresco/alfresco-enterprise-repo-base:latest
+
+USER root
+
+# Set default Docker context
+ARG RESOURCE_PATH=target
+
+# Set default environment args
+ARG GROUPNAME=Alfresco
+ARG IMAGEUSERNAME=alfresco
+ARG TOMCAT_DIR=/usr/local/tomcat
+
+# Clean previous amps
+RUN rm ${TOMCAT_DIR}/amps/*
+
+# Copy the amps from build context to the appropriate location for your application server
+COPY ${RESOURCE_PATH}/amps ${TOMCAT_DIR}/amps
+
+RUN chgrp -R ${GROUPNAME} ${TOMCAT_DIR}/amps && \
+    chmod 664 ${TOMCAT_DIR}/amps/alfresco-share-services-*.amp
+
+# Remove installed amps
+RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar uninstall \
+    org.alfresco.integrations.google.docs \
+    ${TOMCAT_DIR}/webapps/alfresco
+RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar uninstall \
+    alfresco-aos-module \
+    ${TOMCAT_DIR}/webapps/alfresco
+
+# Apply Share Services amp
+RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar install \
+    ${TOMCAT_DIR}/amps \
+    ${TOMCAT_DIR}/webapps/alfresco -directory -nobackup -force
+
+EXPOSE 8000
+
+USER ${IMAGEUSERNAME}
+

--- a/packaging/docker-acs-share-services/enterprise/pom.xml
+++ b/packaging/docker-acs-share-services/enterprise/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>acs-enterprise-docker-share-services</artifactId>
+    <name>Alfresco Content Services (Enterprise) Docker With Share Services image builder</name>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>org.alfresco</groupId>
+        <artifactId>acs-docker-share-services</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <image.name>alfresco/alfresco-content-repository-share-services</image.name>
+    </properties>
+</project>

--- a/packaging/docker-acs-share-services/enterprise/pom.xml
+++ b/packaging/docker-acs-share-services/enterprise/pom.xml
@@ -15,5 +15,6 @@
 
     <properties>
         <image.name>alfresco/alfresco-content-repository-share-services</image.name>
+        <license-header-location>${project.parent.parent.parent.basedir}</license-header-location>
     </properties>
 </project>

--- a/packaging/docker-acs-share-services/pom.xml
+++ b/packaging/docker-acs-share-services/pom.xml
@@ -1,0 +1,120 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>acs-docker-share-services</artifactId>
+    <name>Alfresco Content Services Docker With Share Services image builder</name>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>org.alfresco</groupId>
+        <artifactId>alfresco-share-packaging</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <image.registry>quay.io</image.registry>
+        <image.tag>latest</image.tag>
+
+        <alfresco.desktop-sync.version>3.4.0-M5</alfresco.desktop-sync.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-share-services</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <useBaseVersion>true</useBaseVersion>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-amps</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.alfresco.services.sync</groupId>
+                                    <artifactId>alfresco-device-sync-repo</artifactId>
+                                    <version>${alfresco.desktop-sync.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>fabric8-maven-plugin</artifactId>
+                    <version>4.4.0</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <skipBuildPom>false</skipBuildPom>
+                        <images>
+                            <image>
+                                <name>${image.name}:${image.tag}</name>
+                                <registry>${image.registry}</registry>
+                                <build>
+                                    <dockerFileDir>${project.basedir}</dockerFileDir>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <profiles>
+        <!-- Builds local image for development & testing only -->
+        <profile>
+            <id>local</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-image</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/packaging/docker-aws/pom.xml
+++ b/packaging/docker-aws/pom.xml
@@ -1,4 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
     <artifactId>share-docker-aws</artifactId>
     <name>Alfresco Share Docker AWS image builder</name>
@@ -15,7 +18,7 @@
         <image.name>alfresco/alfresco-share-aws</image.name>
         <image.tag>latest</image.tag>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.alfresco</groupId>
@@ -24,7 +27,7 @@
             <type>amp</type>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -42,7 +45,7 @@
                 </executions>
             </plugin>
         </plugins>
-        
+
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM alfresco/alfresco-base-tomcat:8.5.43-java-11-openjdk-centos-7
 
 RUN mkdir -p /usr/local/tomcat/shared/classes/alfresco/web-extension
-RUN mkdir -p /usr/local/tomcat/amps_share
+RUN mkdir -p /usr/local/tomcat/amps/share
 RUN mkdir /licenses
 
 COPY target/war /usr/local/tomcat/webapps
 COPY target/alfresco-mmt/* /usr/local/tomcat/alfresco-mmt/
-COPY target/amps_share /usr/local/tomcat/amps_share
+COPY target/amps/share /usr/local/tomcat/amps/share
 
 COPY target/classes/web-extension-samples/share-config-custom.xml /usr/local/tomcat/shared/classes/alfresco/web-extension
 COPY target/classes/web-extension-samples/custom-slingshot-application-context.xml.sample /usr/local/tomcat/shared/classes/alfresco/web-extension
@@ -22,7 +22,7 @@ RUN chmod +x /usr/local/tomcat/shared/classes/alfresco/substituter.sh
 
 # apply amps
 RUN java -jar /usr/local/tomcat/alfresco-mmt/alfresco-mmt*.jar install \
-              /usr/local/tomcat/amps_share /usr/local/tomcat/webapps/share -directory -nobackup -force
+              /usr/local/tomcat/amps/share /usr/local/tomcat/webapps/share -directory -nobackup -force
 
 ENTRYPOINT ["/usr/local/tomcat/shared/classes/alfresco/substituter.sh", "catalina.sh run"]
 

--- a/packaging/docker/pom.xml
+++ b/packaging/docker/pom.xml
@@ -1,4 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
     <artifactId>share-docker</artifactId>
     <name>Alfresco Share Docker image builder</name>
@@ -11,9 +14,8 @@
     </parent>
 
     <properties>
-        <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>
         <!-- Alfresco GoogleDocs integration version -->
-        <alfresco.googledocs.version>3.2.0</alfresco.googledocs.version>
+        <dependency.alfresco-googledrive-share.version>3.2.0</dependency.alfresco-googledrive-share.version>
 
         <image.registry>quay.io</image.registry>
         <image.name>alfresco/alfresco-share</image.name>
@@ -29,15 +31,17 @@
             <version>${project.version}</version>
             <type>war</type>
         </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-mmt</artifactId>
             <version>${dependency.alfresco-mmt.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.alfresco.integrations</groupId>
             <artifactId>alfresco-googledrive-share</artifactId>
-            <version>${alfresco.googledocs.version}</version>
+            <version>${dependency.alfresco-googledrive-share.version}</version>
             <type>amp</type>
         </dependency>
     </dependencies>
@@ -46,9 +50,9 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
-                <filtering>false</filtering>
             </resource>
         </resources>
+
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -59,6 +63,7 @@
                             <goal>resources</goal>
                         </goals>
                     </execution>
+
                     <execution>
                         <id>copy-resources</id>
                         <phase>process-resources</phase>
@@ -103,6 +108,7 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+
                     <execution>
                         <id>copy-resources</id>
                         <phase>process-resources</phase>
@@ -122,10 +128,10 @@
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-googledrive-share</artifactId>
-                                    <version>${alfresco.googledocs.version}</version>
+                                    <version>${dependency.alfresco-googledrive-share.version}</version>
                                     <type>amp</type>
                                     <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
+                                    <outputDirectory>${project.build.directory}/amps/share</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -159,28 +165,14 @@
     </build>
 
     <profiles>
+        <!-- Builds local image for development & testing only -->
         <profile>
             <id>local</id>
-            <!-- Builds local image for development & testing only -->
             <build>
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>fabric8-maven-plugin</artifactId>
-                        <configuration>
-                            <verbose>true</verbose>
-                            <skipBuildPom>false</skipBuildPom>
-                            <images>
-                                <!-- Default image configuration - used by the *local* and *intenal* profiles -->
-                                <image>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <registry>${image.registry}</registry>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}</dockerFileDir>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>build-image</id>
@@ -195,9 +187,9 @@
             </build>
         </profile>
 
+        <!-- Builds and publishes image to Quay -->
         <profile>
             <id>internal</id>
-            <!-- Builds and publishes image to Quay -->
             <build>
                 <plugins>
                     <plugin>
@@ -218,9 +210,9 @@
             </build>
         </profile>
 
+        <!-- Builds and publishes release image to Quay -->
         <profile>
             <id>release</id>
-            <!-- Builds and publishes release image to Quay -->
             <build>
                 <plugins>
                     <plugin>
@@ -232,6 +224,13 @@
                             <images>
                                 <image>
                                     <name>${image.name}:${project.version}</name>
+                                    <build>
+                                        <dockerFileDir>${project.basedir}</dockerFileDir>
+                                    </build>
+                                </image>
+
+                                <image>
+                                    <name>${image.name}:${project.version}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
                                         <dockerFileDir>${project.basedir}</dockerFileDir>
@@ -239,6 +238,7 @@
                                 </image>
                             </images>
                         </configuration>
+
                         <executions>
                             <execution>
                                 <id>build-push-image</id>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -1,13 +1,17 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+    <artifactId>alfresco-share-packaging</artifactId>
+    <name>Packaging Alfresco Share</name>
+    <packaging>pom</packaging>
+
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-share-parent</artifactId>
         <version>7.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>alfresco-share-packaging</artifactId>
-    <name>Packaging Alfresco Share</name>
-    <packaging>pom</packaging>
 
     <properties>
         <highest.basedir>${basedir}/../../..</highest.basedir>
@@ -26,8 +30,12 @@
         <!-- Installer version that will be used in the final name -->
         <installer.version.name>${project.version}</installer.version.name>
 
+        <!-- Alfresco Module Management Tool version -->
+        <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>
+
+        <license-header-location>${project.parent.parent.parent.basedir}</license-header-location>
     </properties>
-    
+
     <build>
         <pluginManagement>
             <plugins>
@@ -44,8 +52,9 @@
         <module>distribution</module>
         <module>webeditor</module>
         <module>wcmqs</module>
-		<module>docker</module>
+        <module>docker</module>
         <module>docker-aws</module>
+        <module>docker-acs-share-services</module>
     </modules>
-    
+
 </project>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -32,8 +32,6 @@
 
         <!-- Alfresco Module Management Tool version -->
         <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>
-
-        <license-header-location>${project.parent.parent.parent.basedir}</license-header-location>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,18 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+    <artifactId>alfresco-share-parent</artifactId>
+    <name>Alfresco Share Parent</name>
+    <packaging>pom</packaging>
+    <version>7.0.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
         <version>12</version>
     </parent>
-
-    <artifactId>alfresco-share-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <name>Alfresco Share Parent</name>
 
     <modules>
         <module>share-services</module>
@@ -29,12 +31,8 @@
         <version.minor>0</version.minor>
         <version.revision>0</version.revision>
 
-        <!-- Version of Alfresco Platform to depend on -->
-        <alfresco.platform.version>7.0.0-A3</alfresco.platform.version>
-        <alfresco.content-services.version>7.0.0-A16</alfresco.content-services.version>
-        
         <!-- Version of Alfresco Community Repo to depend on -->
-        <dependency.alfresco-community-repo.version>8.345</dependency.alfresco-community-repo.version>
+        <dependency.alfresco-community-repo.version>8.346</dependency.alfresco-community-repo.version>
 
         <!-- Java 8 compatibility -->
         <maven.compile.source>1.8</maven.compile.source>
@@ -42,7 +40,8 @@
 
         <maven.build.sourceVersion>1.8</maven.build.sourceVersion>
 
-        <maven.distributionManagement.snapshot.url>https://artifacts.alfresco.com/nexus/content/repositories/snapshots</maven.distributionManagement.snapshot.url>
+        <maven.distributionManagement.snapshot.url>https://artifacts.alfresco.com/nexus/content/repositories/snapshots
+        </maven.distributionManagement.snapshot.url>
         <argLine>-Xmx2G -Duser.language=en -Dcom.sun.management.jmxremote</argLine>
 
         <dependency.spring.version>5.2.9.RELEASE</dependency.spring.version>
@@ -70,7 +69,8 @@
         <runtime.data.folder>${runtime.parent.folder}/runtime</runtime.data.folder>
         <runtime.tomcat.conf.folder>${runtime.parent.folder}/tomcat</runtime.tomcat.conf.folder>
         <runtime.solr.folder>${runtime.data.folder}/solr4-instance</runtime.solr.folder>
-        <alfresco.properties.file>${runtime.tomcat.conf.folder}/shared/classes/alfresco-global.properties</alfresco.properties.file>
+        <alfresco.properties.file>${runtime.tomcat.conf.folder}/shared/classes/alfresco-global.properties
+        </alfresco.properties.file>
         <!-- Define the location where alfresco will store its content files, i.e. *.bin) -->
         <dir.root>${runtime.data.folder}/alf_data</dir.root>
 
@@ -87,17 +87,15 @@
         <test.working.dir>${project.build.directory}</test.working.dir>
         <img.exe>convert</img.exe>
         <swf.exe>pdf2swf</swf.exe>
-
         <license-maven-plugin.version>3.0</license-maven-plugin.version>
-        <license-header-location>${maven.multiModuleProjectDirectory}</license-header-location>
     </properties>
 
-   <scm>
-     <connection>scm:git:https://github.com/Alfresco/share.git/</connection>
-     <developerConnection>scm:git:https://github.com/Alfresco/share.git</developerConnection>
-     <url>https://github.com/Alfresco/share</url>
-     <tag>alfresco-share-parent--A2</tag>
-   </scm>
+    <scm>
+        <connection>scm:git:https://github.com/Alfresco/share.git/</connection>
+        <developerConnection>scm:git:https://github.com/Alfresco/share.git</developerConnection>
+        <url>https://github.com/Alfresco/share</url>
+        <tag>alfresco-share-parent--A2</tag>
+    </scm>
     <pluginRepositories>
         <pluginRepository>
             <!-- Only used for the customised version of yuicompressor in yuicompressor-maven-plugin -->
@@ -109,8 +107,7 @@
     <distributionManagement>
         <repository>
             <id>alfresco-internal</id>
-         <!--   <url>https://artifacts.alfresco.com/nexus/content/repositories/internal-releases</url>-->
- 	    <url>https://artifacts.alfresco.com/nexus/content/repositories/releases</url>
+            <url>https://artifacts.alfresco.com/nexus/content/repositories/releases</url>
         </repository>
         <snapshotRepository>
             <id>alfresco-internal-snapshots</id>
@@ -120,15 +117,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Import all dependencyManagement from Alfresco Platform
-            <dependency>
-                <groupId>org.alfresco</groupId>
-                <artifactId>alfresco-parent</artifactId>
-                <version>6.0.</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
--->
             <!-- Override dependencies with the locally defined versions -->
             <dependency>
                 <groupId>org.alfresco</groupId>
@@ -156,42 +144,42 @@
                 <version>${dependency.webscripts.version}</version>
             </dependency>
             <dependency>
-               <groupId>org.alfresco.surf</groupId>
-               <artifactId>spring-surf</artifactId>
-               <version>${dependency.surf.version}</version>
-               <exclusions>
-               <!-- surf pulls in a an un-patched version, MNT-20234 -->
+                <groupId>org.alfresco.surf</groupId>
+                <artifactId>spring-surf</artifactId>
+                <version>${dependency.surf.version}</version>
+                <exclusions>
+                    <!-- surf pulls in a an un-patched version, MNT-20234 -->
                     <exclusion>
                         <groupId>com.asual.lesscss</groupId>
                         <artifactId>lesscss-engine</artifactId>
                     </exclusion>
-               </exclusions>
+                </exclusions>
             </dependency>
             <dependency>
-               <groupId>org.alfresco.surf</groupId>
-               <artifactId>spring-surf-api</artifactId>
-               <version>${dependency.surf.version}</version>
+                <groupId>org.alfresco.surf</groupId>
+                <artifactId>spring-surf-api</artifactId>
+                <version>${dependency.surf.version}</version>
             </dependency>
             <dependency>
-               <groupId>org.apache.httpcomponents</groupId>
-               <artifactId>httpclient</artifactId>
-               <version>${dependency.httpcomponents.version}</version>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${dependency.httpcomponents.version}</version>
             </dependency>
             <dependency>
-               <groupId>org.apache.httpcomponents</groupId>
-               <artifactId>httpmime</artifactId>
-               <version>${dependency.httpcomponents.version}</version>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>${dependency.httpcomponents.version}</version>
             </dependency>
             <dependency>
-               <groupId>javax.servlet</groupId>
-               <artifactId>javax.servlet-api</artifactId>
-               <version>4.0.1</version>
-               <scope>provided</scope>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>4.0.1</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
-               <groupId>commons-lang</groupId>
-               <artifactId>commons-lang</artifactId>
-               <version>2.6</version>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
@@ -226,34 +214,34 @@
             </dependency>
             <!-- SHA-2404 -->
             <dependency>
-              <groupId>org.keycloak</groupId>
-              <artifactId>keycloak-servlet-filter-adapter</artifactId>
-              <version>${dependency.keycloak.version}</version>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-servlet-filter-adapter</artifactId>
+                <version>${dependency.keycloak.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.keycloak</groupId>
-              <artifactId>keycloak-authz-client</artifactId>
-              <version>${dependency.keycloak.version}</version>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-authz-client</artifactId>
+                <version>${dependency.keycloak.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.keycloak</groupId>
-              <artifactId>keycloak-core</artifactId>
-              <version>${dependency.keycloak.version}</version>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-core</artifactId>
+                <version>${dependency.keycloak.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.keycloak</groupId>
-              <artifactId>keycloak-adapter-core</artifactId>
-              <version>${dependency.keycloak.version}</version>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-core</artifactId>
+                <version>${dependency.keycloak.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.keycloak</groupId>
-              <artifactId>keycloak-adapter-spi</artifactId>
-              <version>${dependency.keycloak.version}</version>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-spi</artifactId>
+                <version>${dependency.keycloak.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.keycloak</groupId>
-              <artifactId>keycloak-servlet-adapter-spi</artifactId>
-              <version>${dependency.keycloak.version}</version>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-servlet-adapter-spi</artifactId>
+                <version>${dependency.keycloak.version}</version>
             </dependency>
             <!-- SHA-2400 -->
             <dependency>
@@ -263,19 +251,19 @@
             </dependency>
             <!-- SHA-2432 -->
             <dependency>
-              <groupId>org.apache.taglibs</groupId>
-              <artifactId>taglibs-standard-spec</artifactId>
-              <version>${dependency.apache.taglibs.version}</version>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-spec</artifactId>
+                <version>${dependency.apache.taglibs.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.apache.taglibs</groupId>
-              <artifactId>taglibs-standard-impl</artifactId>
-              <version>${dependency.apache.taglibs.version}</version>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-impl</artifactId>
+                <version>${dependency.apache.taglibs.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.apache.taglibs</groupId>
-              <artifactId>taglibs-standard-jstlel</artifactId>
-              <version>${dependency.apache.taglibs.version}</version>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-jstlel</artifactId>
+                <version>${dependency.apache.taglibs.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -297,8 +285,8 @@
 
     <build>
         <plugins>
-        <plugin>
-            <groupId>com.mycila</groupId>
+            <plugin>
+                <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <version>${license-maven-plugin.version}</version>
                 <configuration>
@@ -314,20 +302,22 @@
                     </mapping>
                 </configuration>
                 <executions>
-                <execution>
-                    <id>validate-license</id>
-                    <phase>validate</phase>
-                    <goals>
-                      <goal>check</goal>
-                    </goals>
-                </execution>
+                    <execution>
+                        <id>validate-license</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.alfresco.maven.plugin</groupId>
                 <artifactId>alfresco-maven-plugin</artifactId>
                 <version>${dependency.alfresco-sdk.version}</version>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -353,7 +343,7 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
                 <executions>
-                <!-- Read alfresco-global.properties if it exists, to use it for cleaning runtime data (e.g. which database?) -->
+                    <!-- Read alfresco-global.properties if it exists, to use it for cleaning runtime data (e.g. which database?) -->
                     <execution>
                         <id>read-alfresco-global-properties</id>
                         <phase>initialize</phase>
@@ -382,16 +372,16 @@
                         <configuration>
                             <exportAntProperties>true</exportAntProperties>
                             <target>
-                                <property name="db.driver" value="org.postgresql.Driver" />
-                                <property name="db.name" value="alfresco" />
-                                <property name="db.url" value="jdbc:postgresql:${db.name}" />
-                                <property name="db.master.url" value="jdbc:postgresql:template1" />
-                                <property name="db.username" value="alfresco" />
-                                <property name="db.password" value="alfresco" />
-                                <property name="db.master.username" value="alfresco" />
-                                <property name="db.master.password" value="alfresco" />
-                                <property name="db.drop.command" value="drop database if exists ${db.name}" />
-                                <property name="db.create.command" value="create database ${db.name}" />
+                                <property name="db.driver" value="org.postgresql.Driver"/>
+                                <property name="db.name" value="alfresco"/>
+                                <property name="db.url" value="jdbc:postgresql:${db.name}"/>
+                                <property name="db.master.url" value="jdbc:postgresql:template1"/>
+                                <property name="db.username" value="alfresco"/>
+                                <property name="db.password" value="alfresco"/>
+                                <property name="db.master.username" value="alfresco"/>
+                                <property name="db.master.password" value="alfresco"/>
+                                <property name="db.drop.command" value="drop database if exists ${db.name}"/>
+                                <property name="db.create.command" value="create database ${db.name}"/>
                             </target>
                         </configuration>
                     </execution>
@@ -447,7 +437,8 @@
                     <configuration>
                         <archive>
                             <manifestEntries>
-                                <Specification-Version>${version.major}.${version.minor}.${version.revision}</Specification-Version>
+                                <Specification-Version>${version.major}.${version.minor}.${version.revision}
+                                </Specification-Version>
                                 <Implementation-Version>${project.version}</Implementation-Version>
                                 <Build-Date>${maven.build.timestamp}</Build-Date>
                                 <Build-Name>${bamboo_planName}</Build-Name>
@@ -463,7 +454,8 @@
                     <configuration>
                         <archive>
                             <manifestEntries>
-                                <Specification-Version>${version.major}.${version.minor}.${version.revision}</Specification-Version>
+                                <Specification-Version>${version.major}.${version.minor}.${version.revision}
+                                </Specification-Version>
                                 <Implementation-Version>${project.version}</Implementation-Version>
                                 <Build-Date>${maven.build.timestamp}</Build-Date>
                                 <Build-Name>${bamboo_planName}</Build-Name>
@@ -475,7 +467,8 @@
                                 <manifestSection>
                                     <name>Source-control</name>
                                     <manifestEntries>
-                                        <Last-change-Revision>${bamboo_custom_svn_lastchange_revision_number}</Last-change-Revision>
+                                        <Last-change-Revision>${bamboo_custom_svn_lastchange_revision_number}
+                                        </Last-change-Revision>
                                         <Source-Revision>${bamboo_repository_revision_number}</Source-Revision>
                                         <Source-Url>${bamboo_planRepository_repositoryUrl}</Source-Url>
                                     </manifestEntries>
@@ -529,36 +522,36 @@
                 </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>
-                	<groupId>org.eclipse.m2e</groupId>
-                	<artifactId>lifecycle-mapping</artifactId>
-                	<version>1.0.0</version>
-                	<configuration>
-                		<lifecycleMappingMetadata>
-                			<pluginExecutions>
-                				<pluginExecution>
-                					<pluginExecutionFilter>
-                						<groupId>
-                							org.codehaus.mojo
-                						</groupId>
-                						<artifactId>
-                							license-maven-plugin
-                						</artifactId>
-                						<versionRange>
-                							[1.8,)
-                						</versionRange>
-                						<goals>
-                							<goal>
-                								check-file-header
-                							</goal>
-                						</goals>
-                					</pluginExecutionFilter>
-                					<action>
-                						<ignore />
-                					</action>
-                				</pluginExecution>
-                			</pluginExecutions>
-                		</lifecycleMappingMetadata>
-                	</configuration>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>
+                                            org.codehaus.mojo
+                                        </groupId>
+                                        <artifactId>
+                                            license-maven-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [1.8,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>
+                                                check-file-header
+                                            </goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -592,56 +585,56 @@
                 <plugins>
 
                     <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-dependency-plugin</artifactId>
-                      <executions>
-                        <!-- Download and unpack the tomcat config zip file -->
-                        <execution>
-                          <id>unpack-tomcat-config</id>
-                          <phase>generate-resources</phase>
-                          <goals>
-                            <goal>unpack</goal>
-                          </goals>
-                          <configuration>
-                            <outputDirectory>${project.build.directory}/tomcat-conf</outputDirectory>
-                            <artifactItems>
-                              <artifactItem>
-                                <groupId>org.alfresco</groupId>
-                                <artifactId>alfresco-dev-tomcat</artifactId>
-                                <version>5.2.3</version>
-                                <classifier>config</classifier>
-                                <overWrite>true</overWrite>
-                                <type>zip</type>
-                              </artifactItem>
-                            </artifactItems>
-                          </configuration>
-                        </execution>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <!-- Download and unpack the tomcat config zip file -->
+                            <execution>
+                                <id>unpack-tomcat-config</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/tomcat-conf</outputDirectory>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.alfresco</groupId>
+                                            <artifactId>alfresco-dev-tomcat</artifactId>
+                                            <version>5.2.3</version>
+                                            <classifier>config</classifier>
+                                            <overWrite>true</overWrite>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
 
-                        <!-- Download and unpack the solr4 config zip file -->
-                        <execution>
-                          <id>unpack-solr4-config</id>
-                          <phase>generate-resources</phase>
-                          <goals>
-                            <goal>unpack</goal>
-                          </goals>
-                          <configuration>
-                            <outputDirectory>${project.build.directory}/solr4</outputDirectory>
-                            <artifactItems>
-                              <artifactItem>
-                                <groupId>org.alfresco</groupId>
-                                  <artifactId>alfresco-solr4</artifactId>
-                                  <version>5.2.3</version>
-                                  <!--<artifactId>alfresco-solrclient</artifactId>-->
-                                <!--<artifactId>alfresco-solr4</artifactId>-->
-                                <!--<version>6.7</version>-->
-                                <classifier>config</classifier>
-                                <overWrite>true</overWrite>
-                                <type>zip</type>
-                              </artifactItem>
-                            </artifactItems>
-                          </configuration>
-                        </execution>
-                      </executions>
+                            <!-- Download and unpack the solr4 config zip file -->
+                            <execution>
+                                <id>unpack-solr4-config</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/solr4</outputDirectory>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.alfresco</groupId>
+                                            <artifactId>alfresco-solr4</artifactId>
+                                            <version>5.2.3</version>
+                                            <!--<artifactId>alfresco-solrclient</artifactId>-->
+                                            <!--<artifactId>alfresco-solr4</artifactId>-->
+                                            <!--<version>6.7</version>-->
+                                            <classifier>config</classifier>
+                                            <overWrite>true</overWrite>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
 
                     <plugin>
@@ -706,16 +699,17 @@
                                 <phase>generate-resources</phase>
                                 <configuration>
                                     <target>
-                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
+                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+                                                 classpathref="maven.plugin.classpath"/>
                                         <if>
-                                            <available file="${runtime.tomcat.conf.folder}" type="dir" />
+                                            <available file="${runtime.tomcat.conf.folder}" type="dir"/>
                                             <then>
-                                                <echo message="Skipping creation of tomcat configuration, already exists: ${runtime.tomcat.conf.folder}" />
+                                                <echo message="Skipping creation of tomcat configuration, already exists: ${runtime.tomcat.conf.folder}"/>
                                             </then>
                                             <else>
-                                                <echo message="Creating tomcat runtime configuration: ${runtime.tomcat.conf.folder}" />
+                                                <echo message="Creating tomcat runtime configuration: ${runtime.tomcat.conf.folder}"/>
                                                 <copy todir="${runtime.tomcat.conf.folder}">
-                                                    <fileset dir="${project.build.directory}/tomcat-conf" />
+                                                    <fileset dir="${project.build.directory}/tomcat-conf"/>
                                                 </copy>
                                             </else>
                                         </if>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <version.revision>0</version.revision>
 
         <!-- Version of Alfresco Community Repo to depend on -->
-        <dependency.alfresco-community-repo.version>8.346</dependency.alfresco-community-repo.version>
+        <dependency.alfresco-community-repo.version>8.345</dependency.alfresco-community-repo.version>
 
         <!-- Java 8 compatibility -->
         <maven.compile.source>1.8</maven.compile.source>
@@ -40,8 +40,7 @@
 
         <maven.build.sourceVersion>1.8</maven.build.sourceVersion>
 
-        <maven.distributionManagement.snapshot.url>https://artifacts.alfresco.com/nexus/content/repositories/snapshots
-        </maven.distributionManagement.snapshot.url>
+        <maven.distributionManagement.snapshot.url>https://artifacts.alfresco.com/nexus/content/repositories/snapshots</maven.distributionManagement.snapshot.url>
         <argLine>-Xmx2G -Duser.language=en -Dcom.sun.management.jmxremote</argLine>
 
         <dependency.spring.version>5.2.9.RELEASE</dependency.spring.version>
@@ -69,8 +68,7 @@
         <runtime.data.folder>${runtime.parent.folder}/runtime</runtime.data.folder>
         <runtime.tomcat.conf.folder>${runtime.parent.folder}/tomcat</runtime.tomcat.conf.folder>
         <runtime.solr.folder>${runtime.data.folder}/solr4-instance</runtime.solr.folder>
-        <alfresco.properties.file>${runtime.tomcat.conf.folder}/shared/classes/alfresco-global.properties
-        </alfresco.properties.file>
+        <alfresco.properties.file>${runtime.tomcat.conf.folder}/shared/classes/alfresco-global.properties</alfresco.properties.file>
         <!-- Define the location where alfresco will store its content files, i.e. *.bin) -->
         <dir.root>${runtime.data.folder}/alf_data</dir.root>
 
@@ -87,7 +85,9 @@
         <test.working.dir>${project.build.directory}</test.working.dir>
         <img.exe>convert</img.exe>
         <swf.exe>pdf2swf</swf.exe>
+
         <license-maven-plugin.version>3.0</license-maven-plugin.version>
+        <license-header-location>${maven.multiModuleProjectDirectory}</license-header-location>
     </properties>
 
     <scm>
@@ -437,8 +437,7 @@
                     <configuration>
                         <archive>
                             <manifestEntries>
-                                <Specification-Version>${version.major}.${version.minor}.${version.revision}
-                                </Specification-Version>
+                                <Specification-Version>${version.major}.${version.minor}.${version.revision}</Specification-Version>
                                 <Implementation-Version>${project.version}</Implementation-Version>
                                 <Build-Date>${maven.build.timestamp}</Build-Date>
                                 <Build-Name>${bamboo_planName}</Build-Name>
@@ -454,8 +453,7 @@
                     <configuration>
                         <archive>
                             <manifestEntries>
-                                <Specification-Version>${version.major}.${version.minor}.${version.revision}
-                                </Specification-Version>
+                                <Specification-Version>${version.major}.${version.minor}.${version.revision}</Specification-Version>
                                 <Implementation-Version>${project.version}</Implementation-Version>
                                 <Build-Date>${maven.build.timestamp}</Build-Date>
                                 <Build-Name>${bamboo_planName}</Build-Name>
@@ -467,8 +465,7 @@
                                 <manifestSection>
                                     <name>Source-control</name>
                                     <manifestEntries>
-                                        <Last-change-Revision>${bamboo_custom_svn_lastchange_revision_number}
-                                        </Last-change-Revision>
+                                        <Last-change-Revision>${bamboo_custom_svn_lastchange_revision_number}</Last-change-Revision>
                                         <Source-Revision>${bamboo_repository_revision_number}</Source-Revision>
                                         <Source-Url>${bamboo_planRepository_repositoryUrl}</Source-Url>
                                     </manifestEntries>

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -1,15 +1,18 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+    <artifactId>share</artifactId>
+    <name>Alfresco Share WAR</name>
+    <description>Alfresco Share</description>
+    <packaging>war</packaging>
+
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-share-parent</artifactId>
         <version>7.0.0-SNAPSHOT</version>
     </parent>
-
-    <artifactId>share</artifactId>
-    <packaging>war</packaging>
-    <name>Alfresco Share WAR</name>
-    <description>Alfresco Share</description>
 
     <properties>
         <tomcat.version>7.0.86</tomcat.version>


### PR DESCRIPTION
Added the submodule that creates a docker image having ACS and Share Services amp applied, created from the current project.
Changes on Travis build so that it builds and uses the newly created image for tests, when not on master branch.
Some cleaning, aligning and formattingall poms, so that follow the same structure.