### PR TITLE
[MNT-20006] Post activity on site document details opening. Allow edit metadata page opening (when user is not member)

### DIFF
--- a/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/activity.post.json.js
+++ b/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/activity.post.json.js
@@ -42,8 +42,8 @@ function postActivity()
       status.setCode(status.STATUS_BAD_REQUEST, "'site' parameter missing when posting activity");
       return;
    }
-   var site = siteService.getSite(siteId);
-   if (site == null)
+   var siteInfo = siteService.getSiteInfo(siteId);
+   if (siteInfo == null)
    {
       status.setCode(status.STATUS_BAD_REQUEST, "'" + siteId + "' is not a valid site");
       return;

--- a/share/src/main/resources/alfresco/site-webscripts/org/alfresco/share/imports/share-header.lib.js
+++ b/share/src/main/resources/alfresco/site-webscripts/org/alfresco/share/imports/share-header.lib.js
@@ -1558,7 +1558,7 @@ function getHeaderServices() {
          
          // user may have access to document library paths/folders if given explicit permissions
          // other pages should be blocked from direct URL access to avoid messy errors and broken pages
-         if (page.id != "documentlibrary" && page.id != "document-details" && page.id != "folder-details" && !page.url.uri.endsWith("/faceted-search"))
+         if (page.id != "documentlibrary" && page.id != "document-details" && page.id != "folder-details" && !page.url.uri.endsWith("/faceted-search") && page.id != "edit-metadata")
          {
             if (siteData.profile.shortName == "")
             {


### PR DESCRIPTION
This PR has been created for MNT-20006 which contains the analysis made so far. This PR is an alternative for #286 

The use case:

1. Create private site
2. Upload a document to private site
3. Put an user who is not member of the site as document collaborator
4. With the non member user, search for the document, click the result
5. The document opens with site location
5. The post activity operation fails when opening the document details page
6. Click "edit metadata" option
7. The page doesn't open, showing the error page instead

When the document is accessed by site URL (/share/page/site/{site_name}/document-details?nodeRef...), there is a request to update the site activity which fails since the user is not member of the site. Additionally, when trying to edit metadata, this page also fails.

When the document is accessed by direct document URL (/share/page/document-details?nodeRef...), everything work as expected but the activity is not registered (since the site location is not used).

This PR has a proposal which allows:

- the site activity to be registered when the document details is open - even if user is not member of the site;
- to open the edit metadata page so user can edit document properties;