### PR TITLE
Remove unused Share renderers (used in MyAlfresco sync)

### DIFF
--- a/share/src/main/webapp/components/documentlibrary/documentlist.js
+++ b/share/src/main/webapp/components/documentlibrary/documentlist.js
@@ -1983,16 +1983,6 @@
             return html;
          });
 
-         this.registerRenderer("syncFailed", function(record, label)
-         {
-            return '<span class="banner-more-info-link">' + this.msg("details.banner.more-info") + '</span>' + this.msg("details.banner.sync-failed");
-         });
-
-         this.registerRenderer("syncTransientError", function(record, label)
-         {
-            return '<span class="banner-more-info-link">' + this.msg("details.banner.more-info") + '</span>' + this.msg("details.banner.sync-transient-error");
-         });
-
          /**
           * Date
           */


### PR DESCRIPTION
I faced issue with missing renderers in Share UI (upgrade to Share 6.2.2). After deletion of old Share renderers, error messages disappeared.
Those renderes were used for MyAlfresco synchronization that is not in use anymore and should be removed.
![image](https://user-images.githubusercontent.com/15572097/116823401-993ee200-ab84-11eb-8a51-6129adc34d31.png)
