### PR TITLE
Mitigation for acs-community-packaging/issues/367

### DIFF
--- a/share/src/main/resources/alfresco/share-config.xml
+++ b/share/src/main/resources/alfresco/share-config.xml
@@ -129,7 +129,7 @@
             <!-- minimum length for username and password -->
             <username-min-length>2</username-min-length>
             <password-min-length>3</password-min-length>
-            <show-authorization-status>true</show-authorization-status>
+            <show-authorization-status>false</show-authorization-status>
         </users>
         <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
         <enable-external-users-panel>false</enable-external-users-panel>


### PR DESCRIPTION
The default share-config.xml still ships with <show-authorization-status>true</>, which fails and prevents the users from being loadable in the admin panel, requiring a custom image or sed patch in the entrypoint.

Issue can be referenced below, first introduced in 6.2 and unfixed/undocumented since.

https://github.com/Alfresco/acs-community-packaging/issues/367